### PR TITLE
Improve cross-platform path handling

### DIFF
--- a/generate_pdf.py
+++ b/generate_pdf.py
@@ -1,20 +1,45 @@
 import json
 import os
+import shutil
 import pypandoc
-from datetime import datetime
 
-# 🔧 Absolute path to your pandoc.exe
-pandoc_path = r"C:\Users\jacin\Desktop\pandoc-3.8.2.1\pandoc.exe"
+PANDOC_ENV_VAR = "PANDOC_PATH"
 
-# Force Python to use it
-os.environ["PATH"] = os.path.dirname(pandoc_path) + os.pathsep + os.environ["PATH"]
 
-try:
-    real_path = pypandoc.get_pandoc_path()
-    print(f"[OK] Pandoc detected: {real_path}")
-except OSError:
-    print("[X] Pandoc still not found — using direct path fallback...")
-    pypandoc.pandoc_path = pandoc_path
+def ensure_pandoc_available() -> str:
+    """Ensure a pandoc executable is available and return its path."""
+
+    env_path = os.environ.get(PANDOC_ENV_VAR)
+    if env_path:
+        env_path = os.path.abspath(env_path)
+        if os.path.isfile(env_path):
+            bin_dir = os.path.dirname(env_path)
+            os.environ["PATH"] = bin_dir + os.pathsep + os.environ.get("PATH", "")
+            pypandoc.pandoc_path = env_path
+            print(f"[OK] Pandoc detected via {PANDOC_ENV_VAR}: {env_path}")
+            return env_path
+        else:
+            print(f"[WARN] {PANDOC_ENV_VAR} is set but points to a missing file: {env_path}")
+
+    try:
+        detected = pypandoc.get_pandoc_path()
+        print(f"[OK] Pandoc detected: {detected}")
+        return detected
+    except OSError:
+        pass
+
+    which_path = shutil.which("pandoc")
+    if which_path:
+        pypandoc.pandoc_path = which_path
+        print(f"[OK] Pandoc detected in PATH: {which_path}")
+        return which_path
+
+    raise RuntimeError(
+        "Pandoc executable not found. Install Pandoc or set the PANDOC_PATH environment variable to its location."
+    )
+
+
+ensure_pandoc_available()
 
 def generate_markdown_report(results_path: str, output_folder: str) -> str:
     """Convert fit_results.json into a Markdown report."""
@@ -51,10 +76,11 @@ def generate_markdown_report(results_path: str, output_folder: str) -> str:
 
         # Images
         plot_path = os.path.relpath(item["output_plot"], output_folder).replace("\\", "/")
-        res_path  = item.get("residuals_plot")
+        res_path = item.get("residuals_plot")
         md.append(f"![Plot]({plot_path})")
         if res_path:
-            md.append(f"![Residuals]({os.path.relpath(res_path, output_folder).replace('\\','/')})")
+            residuals_path = os.path.relpath(res_path, output_folder).replace("\\", "/")
+            md.append(f"![Residuals]({residuals_path})")
 
         md.append("\n---\n")
 

--- a/plotinator10000.py
+++ b/plotinator10000.py
@@ -1,6 +1,6 @@
 import tkinter as tk
 from tkinter import ttk, messagebox, filedialog, colorchooser, simpledialog
-import subprocess, os, json, threading
+import subprocess, os, json, threading, platform, webbrowser
 import ttkbootstrap as ttkb  # pip install ttkbootstrap
 import shutil
 import re
@@ -504,7 +504,21 @@ class PlotinatorApp(ttkb.Window):
         latest = sorted(os.listdir(outputs_path))[-1]
         report = os.path.join(outputs_path, latest, "report.pdf")
         if os.path.exists(report):
-            os.startfile(report)
+            try:
+                system = platform.system()
+                if system == "Windows":
+                    os.startfile(report)
+                elif system == "Darwin":
+                    subprocess.run(["open", report], check=False)
+                else:
+                    opener = shutil.which("xdg-open")
+                    if opener:
+                        subprocess.run([opener, report], check=False)
+                    else:
+                        webbrowser.open(f"file://{os.path.abspath(report)}")
+            except Exception as exc:
+                self.show_toast("Warning", f"Could not open report automatically: {exc}", level="warning")
+                return
         else:
             self.show_toast("Warning", "No report.pdf found in latest output.", level="warning")
 


### PR DESCRIPTION
## Summary
- remove hard-coded pandoc path and auto-detect the executable or respect a PANDOC_PATH override
- update report launching logic to use platform-specific open commands with fallbacks for non-Windows hosts

## Testing
- python -m compileall plotinator10000.py generate_pdf.py plot_manager.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910335ab1c48328915d211d547801a9)