### PR TITLE
Add configurable plot styling controls

### DIFF
--- a/plot_manager.py
+++ b/plot_manager.py
@@ -6,6 +6,8 @@ import re
 import math
 import numpy as np
 
+from plotinator.config.style import StyleConfig
+
 PYFIT_RE = re.compile(r"^PYFIT\s+([A-Za-z_]\w*)\s+([-+]?[\d\.]+(?:[eE][-+]?\d+)?)\s+([-+]?[\d\.]+(?:[eE][-+]?\d+)?)$",
                       re.MULTILINE)
 
@@ -120,16 +122,68 @@ def estimate_initial_params(datafile: str, formula: str, params: list[str]) -> d
 def generate_gnuplot_code(
     cfg: dict, out_plot: str | None, out_residuals: str | None = None
 ) -> str:
-    style = cfg.get("style", {})
-    pt  = style.get("point_type", 7)
-    lw  = style.get("line_width", 2)
-    col = style.get("line_color", "black")
+    raw_style = cfg.get("style_model") or cfg.get("style")
+    style_cfg = (
+        raw_style
+        if isinstance(raw_style, StyleConfig)
+        else StyleConfig.from_dict(raw_style, fallback_color=cfg.get("color"))
+    )
 
-    formula  = cfg["fit_formula"]
-    params   = cfg["fit_params"]
+    pt = style_cfg.point_type
+    lw = style_cfg.line_width
+    col = style_cfg.line_color
+
+    formula = cfg["fit_formula"]
+    params = cfg["fit_params"]
     params_csv = ",".join(params)
     datafile = os.path.abspath(cfg["datafile"]).replace("\\", "/")
-    use_err  = cfg.get("error_bars", False)
+    use_err = cfg.get("error_bars", False)
+
+    def _escape(text: str) -> str:
+        return (text or "").replace("\\", "\\\\").replace('"', '\"')
+
+    def _style_commands(title: str, x_label: str, y_label: str, *, force_linear_y: bool = False) -> str:
+        lines: list[str] = [
+            "set encoding utf8",
+            f"set terminal pngcairo size 800,600 font \"{_escape(style_cfg.font_family)},{style_cfg.font_size}\"",
+            f"set title \"{_escape(title)}\" font \",{style_cfg.title_font_size}\"",
+            f"set xlabel \"{_escape(x_label)}\" font \",{style_cfg.axis_label_font_size}\"",
+            f"set ylabel \"{_escape(y_label)}\" font \",{style_cfg.axis_label_font_size}\"",
+            f"set xtics font \",{style_cfg.tick_font_size}\"",
+            f"set ytics font \",{style_cfg.tick_font_size}\"",
+        ]
+
+        if style_cfg.x_scale == "log":
+            lines.append("set logscale x")
+        else:
+            lines.append("unset logscale x")
+
+        if not force_linear_y and style_cfg.y_scale == "log":
+            lines.append("set logscale y")
+        else:
+            lines.append("unset logscale y")
+
+        if style_cfg.x_tick_format:
+            lines.append(f"set format x \"{_escape(style_cfg.x_tick_format)}\"")
+        else:
+            lines.append("set format x")
+
+        if style_cfg.y_tick_format and not force_linear_y:
+            lines.append(f"set format y \"{_escape(style_cfg.y_tick_format)}\"")
+        else:
+            lines.append("set format y")
+
+        if style_cfg.grid:
+            lines.append(f"set grid {style_cfg.grid_layer}")
+        else:
+            lines.append("unset grid")
+
+        if style_cfg.legend_visible and not force_linear_y:
+            lines.append(style_cfg.legend_gnuplot_clause())
+        else:
+            lines.append("unset key")
+
+        return "\n".join(lines)
 
     # Compute smart initial guesses
     guesses = estimate_initial_params(datafile, formula, params)
@@ -148,11 +202,7 @@ def generate_gnuplot_code(
 
 
     code = f"""
-set encoding utf8
-set terminal pngcairo size 800,600
-set title "{cfg['title']}"
-set xlabel "X"
-set ylabel "Y"
+{_style_commands(cfg['title'], style_cfg.axis_label_with_unit('x'), style_cfg.axis_label_with_unit('y'))}
 
 set fit errorvariables
 {init_lines}
@@ -181,10 +231,7 @@ fit f(x) "{datafile}" via {params_csv}
     if out_residuals:
         code += f"""
 set output "{out_residuals}"
-set title "Residuals — {cfg['title']}"
-set xlabel "X"
-set ylabel "Residual (y - f(x))"
-set grid back
+{_style_commands(f"Residuals — {cfg['title']}", style_cfg.axis_label_with_unit('x'), "Residual (y - f(x))", force_linear_y=True)}
 plot "{datafile}" using 1:($2 - f($1)) with points pt {pt} title "Residuals", \\
      0 with lines notitle lc rgb "gray"
 unset output
@@ -229,11 +276,12 @@ def normalize_plots(cfg: dict, config_path: str) -> list[dict]:
         if not datafile or not os.path.exists(datafile):
             raise FileNotFoundError(f"Data file not found for fit '{fit.get('title', 'Untitled')}': {datafile}")
 
-        style = fit.get("style", {}).copy()
-        if "color" in fit and fit["color"]:
-            style.setdefault("line_color", fit["color"])
-        elif "line_color" not in style:
-            style["line_color"] = "#1f77b4"
+        style_cfg = StyleConfig.from_dict(fit.get("style"), fallback_color=fit.get("color"))
+        if fit.get("color"):
+            style_cfg.line_color = fit["color"]
+        else:
+            fit["color"] = style_cfg.line_color
+        style = style_cfg.to_dict()
 
         initial_params = {}
         for key in params:
@@ -249,6 +297,7 @@ def normalize_plots(cfg: dict, config_path: str) -> list[dict]:
                 "datafile": datafile,
                 "residuals": bool(fit.get("residuals", True)),
                 "style": style,
+                "style_model": style_cfg,
                 "fit_params": params,
                 "initial_params": initial_params,
                 "error_bars": bool(fit.get("error_bars", False)),

--- a/plotinator/config/__init__.py
+++ b/plotinator/config/__init__.py
@@ -1,0 +1,5 @@
+"""Configuration models for Plotinator."""
+
+from .style import StyleConfig
+
+__all__ = ["StyleConfig"]

--- a/plotinator/config/style.py
+++ b/plotinator/config/style.py
@@ -1,0 +1,164 @@
+"""Style configuration model for Plotinator plots."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+
+def _coerce_bool(value) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _coerce_int(value, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return int(default)
+
+
+def _coerce_float(value, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return float(default)
+
+
+@dataclass(slots=True)
+class StyleConfig:
+    """Normalized plot styling configuration with sensible defaults."""
+
+    VALID_SCALES: ClassVar[tuple[str, ...]] = ("linear", "log")
+    VALID_GRID_LAYERS: ClassVar[tuple[str, ...]] = ("front", "back")
+    VALID_LEGEND_POSITIONS: ClassVar[dict[str, str]] = {
+        "best": "default",
+        "top left": "top left",
+        "top right": "top right",
+        "bottom left": "bottom left",
+        "bottom right": "bottom right",
+        "center": "center",
+        "outside right": "right outside",
+        "outside left": "left outside",
+    }
+
+    x_label: str = "X"
+    x_unit: str = ""
+    x_scale: str = "linear"
+    x_tick_format: str = ""
+
+    y_label: str = "Y"
+    y_unit: str = ""
+    y_scale: str = "linear"
+    y_tick_format: str = ""
+
+    grid: bool = True
+    grid_layer: str = "back"
+
+    legend_visible: bool = True
+    legend_position: str = "top right"
+
+    font_family: str = "Segoe UI"
+    font_size: int = 11
+    title_font_size: int = 16
+    axis_label_font_size: int = 13
+    tick_font_size: int = 11
+
+    line_color: str = "#1f77b4"
+    line_width: float = 2.0
+    point_type: int = 7
+
+    def __post_init__(self) -> None:
+        self.x_scale = self._validate_scale(self.x_scale)
+        self.y_scale = self._validate_scale(self.y_scale)
+        self.grid_layer = self._validate_grid_layer(self.grid_layer)
+        self.legend_position = self._validate_legend_position(self.legend_position)
+        self.font_size = _coerce_int(self.font_size, 11)
+        self.title_font_size = _coerce_int(self.title_font_size, 16)
+        self.axis_label_font_size = _coerce_int(self.axis_label_font_size, 13)
+        self.tick_font_size = _coerce_int(self.tick_font_size, 11)
+        self.line_width = _coerce_float(self.line_width, 2.0)
+        self.point_type = _coerce_int(self.point_type, 7)
+        self.grid = _coerce_bool(self.grid)
+        self.legend_visible = _coerce_bool(self.legend_visible)
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_dict(cls, raw: dict | None, *, fallback_color: str | None = None) -> "StyleConfig":
+        if not isinstance(raw, dict):
+            raw = {}
+        data = {field.name: raw.get(field.name) for field in cls.__dataclass_fields__.values() if field.init}
+
+        if fallback_color and not data.get("line_color"):
+            data["line_color"] = fallback_color
+
+        clean = {k: v for k, v in data.items() if v is not None}
+        return cls(**clean)
+
+    # ------------------------------------------------------------------
+    def to_dict(self) -> dict:
+        return {
+            "x_label": self.x_label,
+            "x_unit": self.x_unit,
+            "x_scale": self.x_scale,
+            "x_tick_format": self.x_tick_format,
+            "y_label": self.y_label,
+            "y_unit": self.y_unit,
+            "y_scale": self.y_scale,
+            "y_tick_format": self.y_tick_format,
+            "grid": self.grid,
+            "grid_layer": self.grid_layer,
+            "legend_visible": self.legend_visible,
+            "legend_position": self.legend_position,
+            "font_family": self.font_family,
+            "font_size": self.font_size,
+            "title_font_size": self.title_font_size,
+            "axis_label_font_size": self.axis_label_font_size,
+            "tick_font_size": self.tick_font_size,
+            "line_color": self.line_color,
+            "line_width": self.line_width,
+            "point_type": self.point_type,
+        }
+
+    # ------------------------------------------------------------------
+    def axis_label_with_unit(self, axis: str) -> str:
+        if axis == "x":
+            label, unit = self.x_label, self.x_unit
+        else:
+            label, unit = self.y_label, self.y_unit
+        label = label or ("X" if axis == "x" else "Y")
+        if unit:
+            return f"{label} [{unit}]"
+        return label
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def _validate_scale(cls, value: str | None) -> str:
+        if isinstance(value, str) and value.lower() in cls.VALID_SCALES:
+            return value.lower()
+        return "linear"
+
+    @classmethod
+    def _validate_grid_layer(cls, value: str | None) -> str:
+        if isinstance(value, str) and value.lower() in cls.VALID_GRID_LAYERS:
+            return value.lower()
+        return "back"
+
+    @classmethod
+    def _validate_legend_position(cls, value: str | None) -> str:
+        if isinstance(value, str):
+            key = value.strip().lower()
+            for option in cls.VALID_LEGEND_POSITIONS:
+                if key == option:
+                    return option
+        return "top right"
+
+    def legend_gnuplot_clause(self) -> str:
+        mapped = self.VALID_LEGEND_POSITIONS.get(self.legend_position, "top right")
+        if mapped == "default":
+            return "set key"
+        return f"set key {mapped}"
+

--- a/plotinator10000.py
+++ b/plotinator10000.py
@@ -6,6 +6,8 @@ import shutil
 import re
 from ttkbootstrap.constants import *
 
+from plotinator.config import StyleConfig
+
 
 CONFIG_PATH = "config.json"
 
@@ -117,6 +119,7 @@ class PlotinatorApp(ttkb.Window):
         # If it already has 'fits', use it
         if isinstance(raw, dict) and isinstance(raw.get("fits"), list):
             self.config_data = {"fits": raw["fits"]}
+            self._ensure_style_defaults()
 
         # Backwards compatibility: migrate 'plots' -> 'fits'
         elif isinstance(raw, dict) and isinstance(raw.get("plots"), list):
@@ -131,6 +134,7 @@ class PlotinatorApp(ttkb.Window):
                     "color":     (p.get("style", {}) or {}).get("line_color", "#1f77b4"),
                 })
             self.config_data = {"fits": migrated}
+            self._ensure_style_defaults()
 
             # (Optional) write back the migrated file so future loads are clean
             try:
@@ -161,6 +165,12 @@ class PlotinatorApp(ttkb.Window):
             datafile = os.path.basename(fit.get("datafile", ""))  # cleaner filename only
             residuals = "✅" if fit.get("residuals", False) else "❌"
             self.tree.insert("", "end", values=(title, formula, datafile, residuals))
+
+    def _ensure_style_defaults(self):
+        for fit in self.config_data.get("fits", []):
+            style_cfg = StyleConfig.from_dict(fit.get("style"), fallback_color=fit.get("color"))
+            fit["style"] = style_cfg.to_dict()
+            fit["color"] = style_cfg.line_color
 
 
     #-------- Utilities ------------------
@@ -249,7 +259,8 @@ class PlotinatorApp(ttkb.Window):
             "datafile": "",
             "residuals": True,
             "color": "#1f77b4",
-            "parameters": {"a": 1.0, "b": 1.0}
+            "parameters": {"a": 1.0, "b": 1.0},
+            "style": StyleConfig().to_dict(),
         }
         self.config_data.setdefault("fits", []).append(new_fit)
         index = len(self.config_data["fits"]) - 1
@@ -278,6 +289,7 @@ class PlotinatorApp(ttkb.Window):
     def edit_fit(self, index):
         """Open the edit window for a specific fit index."""
         fit = self.config_data["fits"][index]
+        style_cfg = StyleConfig.from_dict(fit.get("style"), fallback_color=fit.get("color"))
         edit_win = tk.Toplevel(self)
         edit_win.title(f"Edit Fit #{index + 1}")
         edit_win.geometry("600x600")
@@ -367,19 +379,106 @@ class PlotinatorApp(ttkb.Window):
         residuals_var = tk.BooleanVar(value=fit.get("residuals", True))
         tk.Checkbutton(scrollable_frame, text="Generate residuals plot", variable=residuals_var).pack(anchor="w", padx=10, pady=5)
 
-        # --- Color
-        tk.Label(scrollable_frame, text="Color:").pack(anchor="w", padx=10, pady=2)
-        color_var = tk.StringVar(value=fit.get("color", "#1f77b4"))
+        # --- Axes options
+        x_label_var = tk.StringVar(value=style_cfg.x_label)
+        x_unit_var = tk.StringVar(value=style_cfg.x_unit)
+        x_scale_var = tk.StringVar(value=style_cfg.x_scale)
+        x_tick_format_var = tk.StringVar(value=style_cfg.x_tick_format)
+        y_label_var = tk.StringVar(value=style_cfg.y_label)
+        y_unit_var = tk.StringVar(value=style_cfg.y_unit)
+        y_scale_var = tk.StringVar(value=style_cfg.y_scale)
+        y_tick_format_var = tk.StringVar(value=style_cfg.y_tick_format)
+
+        axes_frame = tk.LabelFrame(scrollable_frame, text="Axes")
+        axes_frame.pack(fill="x", padx=10, pady=8)
+        for col in (1, 3):
+            axes_frame.columnconfigure(col, weight=1)
+
+        tk.Label(axes_frame, text="X label").grid(row=0, column=0, sticky="w", padx=5, pady=2)
+        tk.Entry(axes_frame, textvariable=x_label_var).grid(row=0, column=1, sticky="ew", padx=5, pady=2)
+        tk.Label(axes_frame, text="Unit").grid(row=0, column=2, sticky="w", padx=5, pady=2)
+        tk.Entry(axes_frame, textvariable=x_unit_var).grid(row=0, column=3, sticky="ew", padx=5, pady=2)
+
+        tk.Label(axes_frame, text="X scale").grid(row=1, column=0, sticky="w", padx=5, pady=2)
+        ttk.Combobox(axes_frame, textvariable=x_scale_var, values=list(StyleConfig.VALID_SCALES), state="readonly").grid(row=1, column=1, sticky="ew", padx=5, pady=2)
+        tk.Label(axes_frame, text="Tick format").grid(row=1, column=2, sticky="w", padx=5, pady=2)
+        tk.Entry(axes_frame, textvariable=x_tick_format_var).grid(row=1, column=3, sticky="ew", padx=5, pady=2)
+
+        tk.Label(axes_frame, text="Y label").grid(row=2, column=0, sticky="w", padx=5, pady=2)
+        tk.Entry(axes_frame, textvariable=y_label_var).grid(row=2, column=1, sticky="ew", padx=5, pady=2)
+        tk.Label(axes_frame, text="Unit").grid(row=2, column=2, sticky="w", padx=5, pady=2)
+        tk.Entry(axes_frame, textvariable=y_unit_var).grid(row=2, column=3, sticky="ew", padx=5, pady=2)
+
+        tk.Label(axes_frame, text="Y scale").grid(row=3, column=0, sticky="w", padx=5, pady=2)
+        ttk.Combobox(axes_frame, textvariable=y_scale_var, values=list(StyleConfig.VALID_SCALES), state="readonly").grid(row=3, column=1, sticky="ew", padx=5, pady=2)
+        tk.Label(axes_frame, text="Tick format").grid(row=3, column=2, sticky="w", padx=5, pady=2)
+        tk.Entry(axes_frame, textvariable=y_tick_format_var).grid(row=3, column=3, sticky="ew", padx=5, pady=2)
+
+        # --- Grid & legend
+        grid_var = tk.BooleanVar(value=style_cfg.grid)
+        grid_layer_var = tk.StringVar(value=style_cfg.grid_layer)
+        legend_visible_var = tk.BooleanVar(value=style_cfg.legend_visible)
+        legend_position_var = tk.StringVar(value=style_cfg.legend_position)
+
+        grid_frame = tk.LabelFrame(scrollable_frame, text="Grid & legend")
+        grid_frame.pack(fill="x", padx=10, pady=8)
+        grid_frame.columnconfigure(1, weight=1)
+
+        tk.Checkbutton(grid_frame, text="Show grid", variable=grid_var).grid(row=0, column=0, sticky="w", padx=5, pady=2)
+        ttk.Combobox(grid_frame, textvariable=grid_layer_var, values=list(StyleConfig.VALID_GRID_LAYERS), state="readonly").grid(row=0, column=1, sticky="ew", padx=5, pady=2)
+
+        tk.Checkbutton(grid_frame, text="Show legend", variable=legend_visible_var).grid(row=1, column=0, sticky="w", padx=5, pady=2)
+        ttk.Combobox(grid_frame, textvariable=legend_position_var, values=list(StyleConfig.VALID_LEGEND_POSITIONS.keys()), state="readonly").grid(row=1, column=1, sticky="ew", padx=5, pady=2)
+
+        # --- Fonts
+        font_family_var = tk.StringVar(value=style_cfg.font_family)
+        font_size_var = tk.IntVar(value=style_cfg.font_size)
+        title_font_size_var = tk.IntVar(value=style_cfg.title_font_size)
+        axis_font_size_var = tk.IntVar(value=style_cfg.axis_label_font_size)
+        tick_font_size_var = tk.IntVar(value=style_cfg.tick_font_size)
+
+        fonts_frame = tk.LabelFrame(scrollable_frame, text="Fonts")
+        fonts_frame.pack(fill="x", padx=10, pady=8)
+        fonts_frame.columnconfigure(1, weight=1)
+
+        tk.Label(fonts_frame, text="Family").grid(row=0, column=0, sticky="w", padx=5, pady=2)
+        tk.Entry(fonts_frame, textvariable=font_family_var).grid(row=0, column=1, sticky="ew", padx=5, pady=2)
+
+        tk.Label(fonts_frame, text="Base size").grid(row=1, column=0, sticky="w", padx=5, pady=2)
+        ttk.Spinbox(fonts_frame, from_=6, to=48, textvariable=font_size_var, width=6).grid(row=1, column=1, sticky="w", padx=5, pady=2)
+        tk.Label(fonts_frame, text="Title size").grid(row=1, column=2, sticky="w", padx=5, pady=2)
+        ttk.Spinbox(fonts_frame, from_=8, to=64, textvariable=title_font_size_var, width=6).grid(row=1, column=3, sticky="w", padx=5, pady=2)
+
+        tk.Label(fonts_frame, text="Axis labels").grid(row=2, column=0, sticky="w", padx=5, pady=2)
+        ttk.Spinbox(fonts_frame, from_=6, to=48, textvariable=axis_font_size_var, width=6).grid(row=2, column=1, sticky="w", padx=5, pady=2)
+        tk.Label(fonts_frame, text="Tick labels").grid(row=2, column=2, sticky="w", padx=5, pady=2)
+        ttk.Spinbox(fonts_frame, from_=6, to=48, textvariable=tick_font_size_var, width=6).grid(row=2, column=3, sticky="w", padx=5, pady=2)
+
+        # --- Line & point appearance
+        color_var = tk.StringVar(value=style_cfg.line_color)
+        line_width_var = tk.DoubleVar(value=style_cfg.line_width)
+        point_type_var = tk.IntVar(value=style_cfg.point_type)
+
+        appearance_frame = tk.LabelFrame(scrollable_frame, text="Line & points")
+        appearance_frame.pack(fill="x", padx=10, pady=8)
+        appearance_frame.columnconfigure(1, weight=1)
+
+        tk.Label(appearance_frame, text="Line color").grid(row=0, column=0, sticky="w", padx=5, pady=2)
 
         def choose_color():
             color = colorchooser.askcolor(color_var.get())[1]
             if color:
                 color_var.set(color)
 
-        frame_color = tk.Frame(scrollable_frame)
-        frame_color.pack(fill="x", padx=10)
-        tk.Entry(frame_color, textvariable=color_var, width=10).pack(side="left")
-        tk.Button(frame_color, text="🎨", command=choose_color).pack(side="left", padx=5)
+        color_entry = tk.Entry(appearance_frame, textvariable=color_var)
+        color_entry.grid(row=0, column=1, sticky="ew", padx=5, pady=2)
+        tk.Button(appearance_frame, text="🎨", command=choose_color).grid(row=0, column=2, padx=5, pady=2)
+
+        tk.Label(appearance_frame, text="Line width").grid(row=1, column=0, sticky="w", padx=5, pady=2)
+        ttk.Spinbox(appearance_frame, from_=0.5, to=10.0, increment=0.5, textvariable=line_width_var, width=6).grid(row=1, column=1, sticky="w", padx=5, pady=2)
+
+        tk.Label(appearance_frame, text="Point type").grid(row=1, column=2, sticky="w", padx=5, pady=2)
+        ttk.Spinbox(appearance_frame, from_=0, to=15, textvariable=point_type_var, width=6).grid(row=1, column=3, sticky="w", padx=5, pady=2)
 
         # --- Parameters ---
         tk.Label(scrollable_frame, text="Parameters:").pack(anchor="w", padx=10, pady=(10, 0))
@@ -426,12 +525,39 @@ class PlotinatorApp(ttkb.Window):
             fit["formula"] = formula_var.get()
             fit["datafile"] = data_var.get()
             fit["residuals"] = residuals_var.get()
-            fit["color"] = color_var.get()
+            fit["parameters"] = {k: v.get() for k, v in param_vars.items()}
+
+            style_payload = {
+                "x_label": x_label_var.get().strip(),
+                "x_unit": x_unit_var.get().strip(),
+                "x_scale": x_scale_var.get(),
+                "x_tick_format": x_tick_format_var.get().strip(),
+                "y_label": y_label_var.get().strip(),
+                "y_unit": y_unit_var.get().strip(),
+                "y_scale": y_scale_var.get(),
+                "y_tick_format": y_tick_format_var.get().strip(),
+                "grid": grid_var.get(),
+                "grid_layer": grid_layer_var.get(),
+                "legend_visible": legend_visible_var.get(),
+                "legend_position": legend_position_var.get(),
+                "font_family": font_family_var.get().strip() or style_cfg.font_family,
+                "font_size": font_size_var.get(),
+                "title_font_size": title_font_size_var.get(),
+                "axis_label_font_size": axis_font_size_var.get(),
+                "tick_font_size": tick_font_size_var.get(),
+                "line_color": color_var.get().strip() or style_cfg.line_color,
+                "line_width": line_width_var.get(),
+                "point_type": point_type_var.get(),
+            }
+
+            new_style = StyleConfig.from_dict(style_payload)
+            fit["style"] = new_style.to_dict()
+            fit["color"] = new_style.line_color
+
             self.save_config()
             self.refresh_table()
             self.show_toast(f"Saved '{fit['title']}'", level="info")
             edit_win.destroy()
-            fit["parameters"] = {k: v.get() for k, v in param_vars.items()}
 
 
         tk.Button(scrollable_frame, text="💾 Save", command=save_and_close, bg="#4CAF50", fg="white").pack(pady=15)


### PR DESCRIPTION
## Summary
- add a dedicated style configuration model and defaults
- expose axis, legend, grid, and font controls in the edit dialog and persist them
- generate gnuplot commands from the richer style model, including scales, formats, and grids

## Testing
- python -m compileall plotinator10000.py plot_manager.py plotinator/config/style.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691038bb308c83288081ec05152d1218)