### PR TITLE
Refactor GUI to call engine API directly

### DIFF
--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -1,6 +1,6 @@
 from .config import infer_parameters, normalize_layout, normalize_plots
 from .data_pipeline import apply_preprocessing, prepare_datafile
-from .runner import process_plot, run_batch, run_gnuplot_script
+from .runner import process_plot, run_batch, run_gnuplot_script, run_job
 from .script_builder import (
     compute_residual_metrics,
     estimate_initial_params,
@@ -20,5 +20,6 @@ __all__ = [
     "prepare_datafile",
     "process_plot",
     "run_batch",
+    "run_job",
     "run_gnuplot_script",
 ]

--- a/engine/runner.py
+++ b/engine/runner.py
@@ -6,7 +6,7 @@ import json
 import os
 import subprocess
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Any
+from typing import Any, Callable, Dict
 
 from .config import normalize_plots
 from .data_pipeline import prepare_datafile
@@ -19,8 +19,51 @@ from .script_builder import (
 __all__ = [
     "run_gnuplot_script",
     "process_plot",
+    "run_job",
     "run_batch",
 ]
+
+
+class _EventDispatcher:
+    """Dispatch structured events to an optional callback with CLI fallbacks."""
+
+    def __init__(self, callback: Callable[[dict[str, Any]], None] | None = None) -> None:
+        self._callback = callback
+
+    def emit(self, event_type: str, **payload: Any) -> None:
+        event: dict[str, Any] = {"type": event_type}
+        event.update(payload)
+        if self._callback:
+            self._callback(event)
+        else:
+            self._default_handle(event)
+
+    def log(self, message: str) -> None:
+        self.emit("log", message=message)
+
+    @staticmethod
+    def _default_handle(event: Dict[str, Any]) -> None:
+        etype = event.get("type")
+        if etype == "log":
+            message = event.get("message", "")
+            if message:
+                print(message)
+        elif etype == "job-start":
+            ts = event.get("timestamp") or ""
+            total = event.get("total") or 0
+            print(f"[RUN] Starting batch at {ts} ({total} plots)")
+        elif etype == "plot-start":
+            print(f"[RUN] Processing: {event.get('title', 'Unknown plot')}")
+        elif etype == "plot-complete":
+            print(f"[OK] Finished: {event.get('title', 'Unknown plot')}")
+        elif etype == "plot-error":
+            print(f"[X] Error in one plot: {event.get('error')}")
+        elif etype == "job-complete":
+            results_path = event.get("results_path", "")
+            if results_path:
+                print(f"\n[COMPLETE] All fits complete. Results saved to:\n{results_path}")
+        elif etype == "job-error":
+            print(f"[X] {event.get('error')}")
 
 
 def run_gnuplot_script(gnuplot_code: str, workdir: str) -> str:
@@ -83,10 +126,16 @@ def _dataset_report_entry(dataset: dict) -> dict[str, Any]:
     }
 
 
-def process_plot(plot_cfg: dict, base_output: str) -> dict:
+def process_plot(
+    plot_cfg: dict,
+    base_output: str,
+    dispatcher: _EventDispatcher | None = None,
+) -> dict:
     """Handle a single plot end-to-end: create folder, run fit, residuals, and metrics."""
 
     plot_cfg = copy.deepcopy(plot_cfg)
+    if dispatcher:
+        dispatcher.emit("plot-start", title=plot_cfg.get("title", "Untitled"))
     safe_title = plot_cfg["title"].replace(" ", "_")
     plot_dir = os.path.join(base_output, f"plot_{safe_title}")
     os.makedirs(plot_dir, exist_ok=True)
@@ -178,41 +227,85 @@ def process_plot(plot_cfg: dict, base_output: str) -> dict:
         "confidence_notes": confidence_notes,
     }
 
-    print(f"[OK] Finished: {plot_cfg['title']}")
+    if dispatcher:
+        dispatcher.emit("plot-complete", title=plot_cfg.get("title", "Untitled"), result=result)
+
     return result
 
 
-def run_batch(config_path: str, *, max_workers: int = 4) -> dict[str, Any]:
+def run_job(
+    config: dict,
+    *,
+    config_path: str = "config.json",
+    max_workers: int = 4,
+    output_dir: str | None = None,
+    on_event: Callable[[dict[str, Any]], None] | None = None,
+) -> dict[str, Any]:
+    """Execute a batch fit job from an in-memory config definition."""
+
+    dispatcher = _EventDispatcher(on_event)
+    try:
+        plots = normalize_plots(config, config_path)
+
+        ts = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        base_output = output_dir or os.path.abspath(os.path.join("outputs", ts))
+        os.makedirs(base_output, exist_ok=True)
+
+        dispatcher.emit("job-start", timestamp=ts, total=len(plots), output_dir=base_output)
+
+        results: list[dict[str, Any]] = []
+        futures: dict[Any, dict] = {}
+
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            for plot_cfg in plots:
+                futures[executor.submit(process_plot, plot_cfg, base_output, dispatcher)] = plot_cfg
+
+            for future in as_completed(futures):
+                plot_cfg = futures[future]
+                title = plot_cfg.get("title", "Unnamed plot")
+                try:
+                    result = future.result()
+                except Exception as exc:  # noqa: BLE001 - propagate with logging
+                    dispatcher.emit("plot-error", title=title, error=str(exc))
+                    continue
+                results.append(result)
+
+        all_results = {"timestamp": ts, "results": results}
+        json_path = os.path.join(base_output, "fit_results.json")
+        with open(json_path, "w", encoding="utf-8") as f:
+            json.dump(all_results, f, indent=2, ensure_ascii=False)
+
+        dispatcher.emit(
+            "job-complete",
+            timestamp=ts,
+            results=results,
+            output_dir=base_output,
+            results_path=json_path,
+        )
+
+        return {
+            "timestamp": ts,
+            "results": results,
+            "output_dir": base_output,
+            "results_path": json_path,
+        }
+    except Exception as exc:
+        dispatcher.emit("job-error", error=str(exc))
+        raise
+
+
+def run_batch(
+    config_path: str,
+    *,
+    max_workers: int = 4,
+    on_event: Callable[[dict[str, Any]], None] | None = None,
+) -> dict[str, Any]:
     with open(config_path, "r", encoding="utf-8") as f:
         cfg = json.load(f)
 
-    plots = normalize_plots(cfg, config_path)
-
-    ts = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    base_output = os.path.abspath(os.path.join("outputs", ts))
-    os.makedirs(base_output, exist_ok=True)
-
-    print(f"[RUN] Starting batch at {ts} ({len(plots)} plots)")
-
-    results: list[dict[str, Any]] = []
-    with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        futures = [executor.submit(process_plot, plot_cfg, base_output) for plot_cfg in plots]
-        for future in as_completed(futures):
-            try:
-                results.append(future.result())
-            except Exception as exc:  # noqa: BLE001 - propagate with logging
-                print(f"[X] Error in one plot: {exc}")
-
-    all_results = {"timestamp": ts, "results": results}
-    json_path = os.path.join(base_output, "fit_results.json")
-    with open(json_path, "w", encoding="utf-8") as f:
-        json.dump(all_results, f, indent=2, ensure_ascii=False)
-
-    print(f"\n[COMPLETE] All fits complete. Results saved to:\n{json_path}")
-
-    return {
-        "timestamp": ts,
-        "results": results,
-        "output_dir": base_output,
-        "results_path": json_path,
-    }
+    return run_job(
+        cfg,
+        config_path=config_path,
+        max_workers=max_workers,
+        on_event=on_event,
+    )

--- a/plotinator10000.py
+++ b/plotinator10000.py
@@ -3,15 +3,17 @@ from __future__ import annotations
 import copy
 import json
 import os
-import subprocess
-import sys
+import queue
 import threading
 import tkinter as tk
+from typing import Any
 from pathlib import Path
 from tkinter import filedialog, messagebox
 
 import ttkbootstrap as ttkb
 from ttkbootstrap.constants import *
+
+from engine import run_job
 
 CONFIG_PATH = "config.json"
 
@@ -29,7 +31,9 @@ class PlotinatorApp(ttkb.Window):
         self.folder: Path | None = None
         self.config_data: dict = {"fits": []}
         self.runner_thread: threading.Thread | None = None
-        self._stop_log = threading.Event()
+        self._event_queue: queue.Queue[dict[str, Any]] | None = None
+        self._progress_total = 0
+        self._progress_completed = 0
 
         self._create_widgets()
         self.tree.bind("<Double-1>", self.on_double_click)
@@ -579,32 +583,113 @@ class DatasetDialog(ttkb.Toplevel):
         self.save_config()
         self.progress.configure(value=0)
         self.log_text.delete("1.0", tk.END)
-        self._stop_log.clear()
+        self._progress_total = 0
+        self._progress_completed = 0
+        self._event_queue = queue.Queue()
+
+        def _push_event(event: dict[str, Any]) -> None:
+            if self._event_queue is not None:
+                self._event_queue.put(event)
 
         def _runner() -> None:
-            cmd = [sys.executable, "plot_manager.py", CONFIG_PATH]
             try:
-                process = subprocess.Popen(
-                    cmd,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
-                    text=True,
-                    bufsize=1,
+                run_job(
+                    copy.deepcopy(self.config_data),
+                    config_path=CONFIG_PATH,
+                    on_event=_push_event,
                 )
-            except OSError as exc:
-                self._append_log(f"Failed to start plot_manager.py: {exc}\n")
-                return
-
-            for line in process.stdout:
-                if self._stop_log.is_set():
-                    break
-                self._append_log(line)
-            process.wait()
-            self.progress.configure(value=100)
-            self._append_log("\n[DONE] Batch finished.\n")
+            except Exception:  # noqa: BLE001 - run_job already reports via events
+                pass
+            finally:
+                if self._event_queue is not None:
+                    self._event_queue.put({"type": "job-thread-exit"})
 
         self.runner_thread = threading.Thread(target=_runner, daemon=True)
         self.runner_thread.start()
+        self.after(100, self._poll_events)
+
+    # ------------------------------------------------------------------
+    def _poll_events(self) -> None:
+        if self._event_queue is None:
+            return
+        try:
+            while True:
+                event = self._event_queue.get_nowait()
+                self._handle_engine_event(event)
+        except queue.Empty:
+            pass
+
+        if self._event_queue is not None:
+            self.after(100, self._poll_events)
+
+    # ------------------------------------------------------------------
+    def _handle_engine_event(self, event: dict[str, Any]) -> None:
+        etype = event.get("type")
+        if etype == "log":
+            message = event.get("message", "")
+            if message and not message.endswith("\n"):
+                message += "\n"
+            if message:
+                self._append_log(message)
+            return
+
+        if etype == "job-start":
+            total = int(event.get("total") or 0)
+            self._progress_total = max(total, 0)
+            self._progress_completed = 0
+            self.progress.configure(value=0)
+            ts = event.get("timestamp", "")
+            self._append_log(f"[RUN] Starting batch at {ts} ({total} plots)\n")
+            return
+
+        if etype == "plot-start":
+            title = event.get("title", "Untitled")
+            self._append_log(f"[RUN] Processing: {title}\n")
+            return
+
+        if etype == "plot-complete":
+            self._progress_completed += 1
+            self._update_progress_bar()
+            title = event.get("title", "Untitled")
+            self._append_log(f"[OK] Finished: {title}\n")
+            return
+
+        if etype == "plot-error":
+            self._progress_completed += 1
+            self._update_progress_bar()
+            title = event.get("title", "Untitled")
+            error_msg = event.get("error", "Unknown error")
+            self._append_log(f"[X] Error in {title}: {error_msg}\n")
+            self.show_toast(f"Plot failed: {title}", level="error")
+            return
+
+        if etype == "job-complete":
+            self.progress.configure(value=100)
+            results_path = event.get("results_path")
+            if results_path:
+                self._append_log(f"\n[COMPLETE] Results saved to: {results_path}\n")
+            self.show_toast("Batch complete", level="success")
+            return
+
+        if etype == "job-error":
+            error_msg = event.get("error", "Batch failed")
+            self._append_log(f"[X] {error_msg}\n")
+            messagebox.showerror("Batch failed", error_msg)
+            self.show_toast("Batch failed", level="error")
+            return
+
+        if etype == "job-thread-exit":
+            self.runner_thread = None
+            self._event_queue = None
+            return
+
+    # ------------------------------------------------------------------
+    def _update_progress_bar(self) -> None:
+        if self._progress_total:
+            percent = (self._progress_completed / self._progress_total) * 100
+        else:
+            percent = 0.0
+        self.progress.configure(value=min(percent, 100))
 
     # ------------------------------------------------------------------
     def _append_log(self, text: str) -> None:


### PR DESCRIPTION
## Summary
- add a high-level `run_job` engine entry point that emits structured events and underpins the CLI batch runner
- refactor the Plotinator Tk UI to invoke the engine API directly, consuming progress events for logs and progress updates
- expose the new entry point through the engine package for reuse

## Testing
- python -m compileall engine plotinator10000.py plot_manager.py
- python -m compileall plotinator10000.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691060b74a3c8328b4011909eb52ac12)