### PR TITLE
Modularize report generation into new reports package

### DIFF
--- a/engine/runner.py
+++ b/engine/runner.py
@@ -8,6 +8,9 @@ import subprocess
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Callable, Dict
 
+from reports.markdown_builder import write_markdown_report
+from reports.pdf_exporter import export_pdf
+
 from .config import normalize_plots
 from .data_pipeline import prepare_datafile
 from .script_builder import (
@@ -58,10 +61,21 @@ class _EventDispatcher:
             print(f"[OK] Finished: {event.get('title', 'Unknown plot')}")
         elif etype == "plot-error":
             print(f"[X] Error in one plot: {event.get('error')}")
+        elif etype == "report-markdown-ready":
+            print(f"[REPORT] Markdown saved to: {event.get('markdown_path')}")
+        elif etype == "report-exported":
+            fmt = event.get("format", "pdf")
+            print(f"[REPORT] {fmt.upper()} exported to: {event.get('pdf_path')}")
+        elif etype == "report-error":
+            stage = event.get("stage", "report")
+            print(f"[WARN] Report {stage} failed: {event.get('error')}")
         elif etype == "job-complete":
             results_path = event.get("results_path", "")
             if results_path:
                 print(f"\n[COMPLETE] All fits complete. Results saved to:\n{results_path}")
+            pdf_path = event.get("pdf_path")
+            if pdf_path:
+                print(f"[REPORT] PDF exported to: {pdf_path}")
         elif etype == "job-error":
             print(f"[X] {event.get('error')}")
 
@@ -275,12 +289,44 @@ def run_job(
         with open(json_path, "w", encoding="utf-8") as f:
             json.dump(all_results, f, indent=2, ensure_ascii=False)
 
+        markdown_path: str | None = None
+        pdf_path: str | None = None
+
+        try:
+            markdown_path = str(write_markdown_report(json_path))
+            dispatcher.emit(
+                "report-markdown-ready",
+                markdown_path=markdown_path,
+            )
+        except Exception as exc:  # noqa: BLE001 - surface via events only
+            dispatcher.emit(
+                "report-error",
+                stage="markdown",
+                error=str(exc),
+            )
+        else:
+            try:
+                pdf_path = str(export_pdf(markdown_path))
+                dispatcher.emit(
+                    "report-exported",
+                    pdf_path=pdf_path,
+                    format="pdf",
+                )
+            except Exception as exc:  # noqa: BLE001 - surface via events only
+                dispatcher.emit(
+                    "report-error",
+                    stage="pdf",
+                    error=str(exc),
+                )
+
         dispatcher.emit(
             "job-complete",
             timestamp=ts,
             results=results,
             output_dir=base_output,
             results_path=json_path,
+            markdown_path=markdown_path,
+            pdf_path=pdf_path,
         )
 
         return {
@@ -288,6 +334,8 @@ def run_job(
             "results": results,
             "output_dir": base_output,
             "results_path": json_path,
+            "markdown_path": markdown_path,
+            "pdf_path": pdf_path,
         }
     except Exception as exc:
         dispatcher.emit("job-error", error=str(exc))

--- a/generate_pdf.py
+++ b/generate_pdf.py
@@ -1,158 +1,24 @@
-import json
+from __future__ import annotations
+
 import os
-import shutil
+from pathlib import Path
 
-import pypandoc
+from reports.markdown_builder import write_markdown_report
+from reports.pdf_exporter import export_pdf
 
-PANDOC_ENV_VAR = "PANDOC_PATH"
-
-
-def ensure_pandoc_available() -> str:
-    """Ensure a pandoc executable is available and return its path."""
-
-    env_path = os.environ.get(PANDOC_ENV_VAR)
-    if env_path:
-        env_path = os.path.abspath(env_path)
-        if os.path.isfile(env_path):
-            bin_dir = os.path.dirname(env_path)
-            os.environ["PATH"] = bin_dir + os.pathsep + os.environ.get("PATH", "")
-            pypandoc.pandoc_path = env_path
-            print(f"[OK] Pandoc detected via {PANDOC_ENV_VAR}: {env_path}")
-            return env_path
-        else:
-            print(f"[WARN] {PANDOC_ENV_VAR} is set but points to a missing file: {env_path}")
-
-    try:
-        detected = pypandoc.get_pandoc_path()
-        print(f"[OK] Pandoc detected: {detected}")
-        return detected
-    except OSError:
-        pass
-
-    which_path = shutil.which("pandoc")
-    if which_path:
-        pypandoc.pandoc_path = which_path
-        print(f"[OK] Pandoc detected in PATH: {which_path}")
-        return which_path
-
-    raise RuntimeError(
-        "Pandoc executable not found. Install Pandoc or set the PANDOC_PATH environment variable to its location."
-    )
-
-
-ensure_pandoc_available()
 
 def generate_markdown_report(results_path: str, output_folder: str) -> str:
-    """Convert fit_results.json into a Markdown report."""
-    with open(results_path, "r", encoding="utf-8") as f:
-        data = json.load(f)
+    """Convert ``fit_results.json`` into a Markdown report."""
+    markdown_path = write_markdown_report(
+        Path(results_path),
+        output_folder=Path(output_folder),
+    )
+    return str(markdown_path)
 
-    ts = data.get("timestamp", "")
-    md = [f"# Plotinator Batch Report", f"**Date:** {ts}", "\n---\n"]
 
-    for item in data.get("results", []):
-        title = item["title"]
-        formula = item["formula"]
-        md.append(f"## {title}")
-        md.append(f"**Formula:** `{formula}`  ")
-
-        # Parameters table
-        params = item.get("parameters", {})
-        if params:
-            md.append("**Parameters:**")
-            md.append("| Name | Value | Error |")
-            md.append("|------|-------:|------:|")
-            for name, vals in params.items():
-                md.append(f"| {name} | {vals['value']:.6g} | {vals['error']:.6g} |")
-        else:
-            md.append("_No parameters extracted._")
-
-        # Metrics
-        metrics = item.get("metrics")
-        if metrics:
-            md.append(
-                f"\n**Residual Metrics:**  \n"
-                f"Mean = {metrics['mean']:.4g} Std = {metrics['std']:.4g} RMSE = {metrics['rmse']:.4g}\n"
-            )
-
-        data_source = item.get("data_source") or {}
-        if data_source:
-            md.append("\n**Data Source:**")
-            source_path = data_source.get("path", "")
-            if source_path:
-                md.append(f"- Path: `{source_path}`")
-            columns = data_source.get("columns") or {}
-            if columns:
-                base_cols = []
-                if columns.get("x"):
-                    base_cols.append(f"x → col {columns['x']}")
-                if columns.get("y"):
-                    base_cols.append(f"y → col {columns['y']}")
-                if base_cols:
-                    md.append(f"- Columns: {', '.join(base_cols)}")
-                if columns.get("error"):
-                    md.append(f"- Error column: col {columns['error']}")
-                if columns.get("weight"):
-                    md.append(f"- Weight column: col {columns['weight']}")
-            before = data_source.get("rows_before")
-            after = data_source.get("rows_after")
-            if before is not None and after is not None:
-                md.append(f"- Rows: {after} / {before} used after preprocessing")
-            preprocessing = data_source.get("preprocessing") or []
-            if preprocessing:
-                md.append("- Preprocessing steps:")
-                for step in preprocessing:
-                    if step.get("type") == "filter":
-                        info = step.get("retained_rows")
-                        suffix = f" → {info} rows" if info is not None else ""
-                        md.append(f"  - Filter `{step['expression']}`{suffix}")
-                    else:
-                        md.append(f"  - Transform `{step['target']}` := `{step['expression']}`")
-
-        confidence = item.get("confidence_notes")
-        if confidence:
-            md.append(f"\n> {confidence}")
-
-        # Images
-        plot_path = os.path.relpath(item["output_plot"], output_folder).replace("\\", "/")
-        res_path = item.get("residuals_plot")
-        md.append(f"![Plot]({plot_path})")
-        if res_path:
-            residuals_path = os.path.relpath(res_path, output_folder).replace("\\", "/")
-            md.append(f"![Residuals]({residuals_path})")
-
-        md.append("\n---\n")
-
-    markdown_text = "\n".join(md)
-    md_file = os.path.join(output_folder, "report.md")
-    with open(md_file, "w", encoding="utf-8") as f:
-        f.write(markdown_text)
-    return md_file
-
-def convert_to_pdf(md_path):
-    md_path = os.path.abspath(md_path)
-    pdf_path = md_path.replace(".md", ".pdf")
-
-    # Move temporarily into the markdown folder to ensure image paths work
-    cwd = os.getcwd()
-    md_dir = os.path.dirname(md_path)
-    os.chdir(md_dir)
-
-    try:
-        pypandoc.convert_text(
-            open(md_path, "r", encoding="utf-8").read(),
-            "pdf",
-            format="md",
-            outputfile=pdf_path,
-            extra_args=["--pdf-engine=wkhtmltopdf", "--standalone"]
-        )
-        print(f"[OK] PDF exported successfully: {pdf_path}")
-    except Exception as e:
-        print(f"[ERROR] PDF generation failed: {e}")
-    finally:
-        os.chdir(cwd)
-
-    return pdf_path
+def convert_to_pdf(md_path: str) -> str:
+    pdf_path = export_pdf(md_path)
+    return str(pdf_path)
 
 
 def main():

--- a/plotinator10000.py
+++ b/plotinator10000.py
@@ -663,11 +663,34 @@ class DatasetDialog(ttkb.Toplevel):
             self.show_toast(f"Plot failed: {title}", level="error")
             return
 
+        if etype == "report-markdown-ready":
+            md_path = event.get("markdown_path", "")
+            if md_path:
+                self._append_log(f"[REPORT] Markdown saved to: {md_path}\n")
+            return
+
+        if etype == "report-exported":
+            pdf_path = event.get("pdf_path", "")
+            if pdf_path:
+                self._append_log(f"[REPORT] PDF exported to: {pdf_path}\n")
+            self.show_toast("Report exported", level="success")
+            return
+
+        if etype == "report-error":
+            stage = event.get("stage", "report")
+            error_msg = event.get("error", "Unknown error")
+            self._append_log(f"[WARN] Report {stage} failed: {error_msg}\n")
+            self.show_toast("Report generation issue", level="warning")
+            return
+
         if etype == "job-complete":
             self.progress.configure(value=100)
             results_path = event.get("results_path")
             if results_path:
                 self._append_log(f"\n[COMPLETE] Results saved to: {results_path}\n")
+            pdf_path = event.get("pdf_path")
+            if pdf_path:
+                self._append_log(f"[REPORT] Latest PDF: {pdf_path}\n")
             self.show_toast("Batch complete", level="success")
             return
 
@@ -709,8 +732,16 @@ class DatasetDialog(ttkb.Toplevel):
         if not latest:
             messagebox.showinfo("No report", "Generate a batch before opening a report.")
             return
+        latest_dir = latest.parent
+        pdf_report = latest_dir / "report.pdf"
+        md_report = latest_dir / "report.md"
         webbrowser = __import__("webbrowser")
-        webbrowser.open(latest.parent.as_uri())
+        if pdf_report.exists():
+            webbrowser.open(pdf_report.as_uri())
+        elif md_report.exists():
+            webbrowser.open(md_report.as_uri())
+        else:
+            webbrowser.open(latest_dir.as_uri())
 
     # ------------------------------------------------------------------
     def show_toast(self, message: str, level: str = "info") -> None:

--- a/reports/__init__.py
+++ b/reports/__init__.py
@@ -1,0 +1,12 @@
+"""Reporting utilities for Plotinator."""
+
+from .markdown_builder import build_markdown_document, write_markdown_report
+from .pdf_exporter import export_document, export_pdf, ensure_pandoc_available
+
+__all__ = [
+    "build_markdown_document",
+    "write_markdown_report",
+    "export_document",
+    "export_pdf",
+    "ensure_pandoc_available",
+]

--- a/reports/markdown_builder.py
+++ b/reports/markdown_builder.py
@@ -1,0 +1,152 @@
+"""Markdown report generation utilities."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Iterable
+
+__all__ = [
+    "load_results",
+    "build_markdown_document",
+    "write_markdown_report",
+]
+
+
+def load_results(results_path: str | Path) -> dict[str, Any]:
+    """Load the JSON results file produced by the batch runner."""
+    results_file = Path(results_path)
+    with results_file.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _format_parameters(parameters: dict[str, Any]) -> Iterable[str]:
+    if not parameters:
+        yield "_No parameters extracted._"
+        return
+
+    yield "**Parameters:**"
+    yield "| Name | Value | Error |"
+    yield "|------|-------:|------:|"
+    for name, values in parameters.items():
+        yield f"| {name} | {values['value']:.6g} | {values['error']:.6g} |"
+
+
+def _format_metrics(metrics: dict[str, Any] | None) -> Iterable[str]:
+    if not metrics:
+        return
+
+    yield (
+        "\n**Residual Metrics:**  \n"
+        f"Mean = {metrics['mean']:.4g} Std = {metrics['std']:.4g} RMSE = {metrics['rmse']:.4g}\n"
+    )
+
+
+def _format_data_source(data_source: dict[str, Any] | None) -> Iterable[str]:
+    if not data_source:
+        return
+
+    yield "\n**Data Source:**"
+    source_path = data_source.get("path", "")
+    if source_path:
+        yield f"- Path: `{source_path}`"
+
+    columns = data_source.get("columns") or {}
+    if columns:
+        base_cols: list[str] = []
+        if columns.get("x"):
+            base_cols.append(f"x → col {columns['x']}")
+        if columns.get("y"):
+            base_cols.append(f"y → col {columns['y']}")
+        if base_cols:
+            yield f"- Columns: {', '.join(base_cols)}"
+        if columns.get("error"):
+            yield f"- Error column: col {columns['error']}"
+        if columns.get("weight"):
+            yield f"- Weight column: col {columns['weight']}"
+
+    before = data_source.get("rows_before")
+    after = data_source.get("rows_after")
+    if before is not None and after is not None:
+        yield f"- Rows: {after} / {before} used after preprocessing"
+
+    preprocessing = data_source.get("preprocessing") or []
+    if preprocessing:
+        yield "- Preprocessing steps:"
+        for step in preprocessing:
+            if step.get("type") == "filter":
+                info = step.get("retained_rows")
+                suffix = f" → {info} rows" if info is not None else ""
+                yield f"  - Filter `{step['expression']}`{suffix}"
+            else:
+                yield f"  - Transform `{step['target']}` := `{step['expression']}`"
+
+
+def _format_images(item: dict[str, Any], output_folder: Path) -> Iterable[str]:
+    output_plot = item.get("output_plot")
+    if output_plot:
+        plot_path = Path(output_plot).resolve()
+        rel_plot = Path(os_path_relative(plot_path, output_folder))
+        yield f"![Plot]({rel_plot.as_posix()})"
+
+    residuals_path = item.get("residuals_plot")
+    if residuals_path:
+        rel_res = Path(os_path_relative(Path(residuals_path).resolve(), output_folder))
+        yield f"![Residuals]({rel_res.as_posix()})"
+
+
+def os_path_relative(path: Path, start: Path) -> str:
+    """Return a POSIX-style relative path."""
+    try:
+        rel = path.relative_to(start)
+        return rel.as_posix()
+    except ValueError:
+        return Path(os.path.relpath(str(path), str(start))).as_posix()
+
+
+def build_markdown_document(results: dict[str, Any], output_folder: str | Path) -> str:
+    """Construct the Markdown document as a string."""
+    out_dir = Path(output_folder).resolve()
+    md_lines: list[str] = []
+
+    timestamp = results.get("timestamp", "")
+    md_lines.extend(["# Plotinator Batch Report", f"**Date:** {timestamp}", "\n---\n"])
+
+    for item in results.get("results", []):
+        title = item.get("title", "Untitled plot")
+        formula = item.get("formula", "")
+        md_lines.append(f"## {title}")
+        md_lines.append(f"**Formula:** `{formula}`  ")
+
+        md_lines.extend(_format_parameters(item.get("parameters", {})))
+        md_lines.extend(_format_metrics(item.get("metrics")))
+        md_lines.extend(_format_data_source(item.get("data_source")))
+
+        confidence = item.get("confidence_notes")
+        if confidence:
+            md_lines.append(f"\n> {confidence}")
+
+        md_lines.extend(_format_images(item, out_dir))
+        md_lines.append("\n---\n")
+
+    return "\n".join(md_lines)
+
+
+def write_markdown_report(
+    results_path: str | Path,
+    *,
+    output_folder: str | Path | None = None,
+    filename: str = "report.md",
+) -> Path:
+    """Generate a Markdown report file from a results JSON path."""
+    results_file = Path(results_path)
+    output_dir = Path(output_folder) if output_folder else results_file.parent
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    results = load_results(results_file)
+    markdown_text = build_markdown_document(results, output_dir)
+
+    markdown_path = output_dir / filename
+    markdown_path.write_text(markdown_text, encoding="utf-8")
+    return markdown_path

--- a/reports/pdf_exporter.py
+++ b/reports/pdf_exporter.py
@@ -1,0 +1,101 @@
+"""Utilities for exporting Markdown reports via Pandoc."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+from typing import Iterable
+
+import pypandoc
+
+PANDOC_ENV_VAR = "PANDOC_PATH"
+DEFAULT_EXTRA_ARGS = {
+    "pdf": ["--pdf-engine=wkhtmltopdf", "--standalone"],
+}
+
+__all__ = ["ensure_pandoc_available", "export_document", "export_pdf"]
+
+
+def ensure_pandoc_available() -> str:
+    """Ensure Pandoc is available and return its executable path."""
+    env_path = os.environ.get(PANDOC_ENV_VAR)
+    if env_path:
+        env_path = os.path.abspath(env_path)
+        if os.path.isfile(env_path):
+            bin_dir = os.path.dirname(env_path)
+            os.environ["PATH"] = bin_dir + os.pathsep + os.environ.get("PATH", "")
+            pypandoc.pandoc_path = env_path
+            return env_path
+
+    try:
+        detected = pypandoc.get_pandoc_path()
+        return detected
+    except OSError:
+        pass
+
+    which_path = shutil.which("pandoc")
+    if which_path:
+        pypandoc.pandoc_path = which_path
+        return which_path
+
+    raise RuntimeError(
+        "Pandoc executable not found. Install Pandoc or set the PANDOC_PATH environment variable to its location."
+    )
+
+
+def export_document(
+    markdown_path: str | Path,
+    *,
+    output_format: str = "pdf",
+    output_path: str | Path | None = None,
+    extra_args: Iterable[str] | None = None,
+) -> Path:
+    """Export a Markdown file to the requested format using Pandoc."""
+    ensure_pandoc_available()
+
+    md_path = Path(markdown_path).resolve()
+    out_dir = md_path.parent
+
+    if output_path is None:
+        suffix = f".{output_format}" if not output_format.startswith(".") else output_format
+        out_path = md_path.with_suffix(suffix)
+    else:
+        out_path = Path(output_path)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    args = list(extra_args) if extra_args is not None else list(DEFAULT_EXTRA_ARGS.get(output_format, []))
+
+    cwd = os.getcwd()
+    os.chdir(out_dir)
+    try:
+        target_name = out_path.name if out_path.parent == out_dir else md_path.with_suffix(f".{output_format}").name
+        pypandoc.convert_file(
+            md_path.name,
+            to=output_format,
+            format="md",
+            outputfile=target_name,
+            extra_args=args or None,
+        )
+        produced_path = out_dir / target_name
+        if produced_path != out_path:
+            shutil.move(produced_path, out_path)
+    finally:
+        os.chdir(cwd)
+
+    return out_path.resolve()
+
+
+def export_pdf(
+    markdown_path: str | Path,
+    *,
+    output_path: str | Path | None = None,
+    extra_args: Iterable[str] | None = None,
+) -> Path:
+    """Export the Markdown file to a PDF."""
+    return export_document(
+        markdown_path,
+        output_format="pdf",
+        output_path=output_path,
+        extra_args=extra_args,
+    )


### PR DESCRIPTION
## Summary
- add a dedicated `reports` package with Markdown assembly and Pandoc export helpers
- refactor the legacy `generate_pdf` script to delegate to the new reporting utilities
- hook the engine event flow and desktop UI into the reporting pipeline with status messaging and report launch improvements

## Testing
- python -m compileall reports engine plotinator10000.py generate_pdf.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910638891888328a84ac00669e0f505)