### PR TITLE
Prepare 0.1.0 release package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2024-05-28
+### Added
+- Initial packaged release of Plotinator 10k with modular engine, configuration schema, and GUI integration.
+- New `pyproject.toml` with console entry points for the CLI runner, GUI, and report generator.
+- Version metadata exposed via `plotinator.__version__`.
+- Developer tooling recommendations, including Ruff configuration and optional development extras.
+
+### Changed
+- Refreshed README with up-to-date architecture, install, and usage guidance for the packaged release.
+- GUI application now exposes a `main()` function for console script entry points.
+
+### Fixed
+- Consolidated packaging metadata to ensure `engine`, `config`, and `plotinator` modules ship together.

--- a/README.md
+++ b/README.md
@@ -1,91 +1,116 @@
 # Plotinator 10k
 
-Plotinator 10k is an automation toolkit for producing high-quality fitting plots from large batches of experimental datasets. The long-term goal is to give laboratory teams an end-to-end workflow: describe fits declaratively, let Plotinator run gnuplot to perform curve fitting, capture numerical diagnostics, and render polished visual and PDF reports without having to drive gnuplot manually.
+Plotinator 10k is a modular automation toolkit for producing high-quality fitting plots from
+large batches of experimental datasets. The stack now ships as a Python package with separate
+layers for configuration, execution, user interface, and reporting so each surface can evolve
+independently.
 
-The repository currently contains the foundations of that workflow in three major areas:
+## Highlights
 
-* A **configuration-driven batch runner** (`plot_manager.py`) that reads a JSON configuration, normalises styling options, executes gnuplot fits, and records residual metrics.
-* A **desktop editor** (`plotinator10000.py`) built with Tkinter + ttkbootstrap that helps non-technical users manage the configuration file, launch batch runs, and inspect logs.
-* A **report generator** (`generate_pdf.py`) that converts the captured JSON results into Markdown and then into a PDF report via Pandoc.
+- **Schema-driven configuration** – The `config` package validates JSON/YAML jobs into strongly-typed
+  dataclasses with helpful error messages, column mapping guards, and preprocessing metadata.
+- **Modular engine** – The `engine` package prepares datasets, generates gnuplot scripts, performs
+  fits, and aggregates metrics. A thin CLI wrapper keeps scripting simple while enabling programmatic
+  reuse.
+- **Desktop GUI** – `plotinator10000.py` provides a ttkbootstrap-powered editor that loads the schema
+  models directly, helping non-technical users manage fits and launch batches without touching JSON.
+- **Reporting pipeline** – `generate_pdf.py` converts engine output into Markdown and PDF artefacts via
+  Pandoc, producing narrative-ready reports after each batch run.
 
-## Vision & planned behaviour
+## Installation
 
-Once complete, Plotinator 10k will provide:
+```bash
+pip install .
+```
 
-1. **Configurable fitting recipes** – Every fit specifies the dataset, column mapping, fit function, styling, and whether residual analysis is required. The batch runner will resolve sensible defaults (e.g., initial parameter guesses) and guard against dangerous input (e.g., blacklisting unsafe symbols in gnuplot expressions).
-2. **Robust batch execution** – The runner will spawn gnuplot for each fit (with optional parallelism), capture stdout/stderr, and persist intermediate artefacts such as plot images, residual plots, and structured JSON summaries.
-3. **Interactive orchestration** – The GUI will let operators pick data folders, add/remove fits, tweak styling, kick off batch jobs, watch progress, and open the latest report with minimal friction.
-4. **Automated reporting** – After each batch run, the Markdown+PDF pipeline will produce a narrative report containing plots, parameter tables, residual statistics, and provenance metadata for each dataset.
-5. **Packaging support** – A future Python package (and potentially platform-specific bundles) will install the CLI + GUI, ensure gnuplot/Pandoc availability, and expose simple entry points for lab teams.
+The project targets **Python 3.10+** and expects external tools to be available on your `PATH`:
 
-## Current status snapshot
+- [gnuplot](http://www.gnuplot.info/) for curve fitting and plotting.
+- [Pandoc](https://pandoc.org/) and [wkhtmltopdf](https://wkhtmltopdf.org/) for PDF conversion.
 
-| Component | Status | Notes |
-|-----------|--------|-------|
-| Configuration schema | 🟡 Draft | `config.json` stores a `fits` list. Layout, style, and dataset metadata helpers exist but still need full validation & documentation.
-| Batch runner (`plot_manager.py`) | 🟡 Core logic present | Generates gnuplot scripts, computes residual metrics with NumPy, and logs output. Needs CLI wiring, error handling polish, and packaging into a callable module.
-| GUI (`plotinator10000.py`) | 🟡 Usable prototype | ttkbootstrap UI loads/saves the config, provides fit editors, and can trigger batch runs (threading stub present). Further work required for long-running process management & result visualisation.
-| Reporting (`generate_pdf.py`) | 🟡 Functional script | Builds Markdown from `fit_results.json` and converts to PDF via Pandoc + wkhtmltopdf. Requires integration hook from batch runner and configuration for output directories.
-| Automated tests | 🔴 Missing | No unit or integration test suite yet.
-| Packaging | 🔴 Pending | Dependencies tracked manually; no `pyproject.toml` or installer scripts yet.
+Optional extras:
 
-## Repository layout
+```bash
+pip install .[yaml]   # enable YAML configuration files via PyYAML
+pip install .[dev]    # install pytest + ruff for local development
+```
+
+## Quickstart
+
+### Run a batch from the CLI
+
+```bash
+plotinator-cli path/to/config.json
+```
+
+- Reads the configuration file using the schema models.
+- Normalises dataset layouts and style configuration.
+- Executes gnuplot fits (with optional parallel workers) and writes results to `outputs/<timestamp>/`.
+
+### Launch the desktop GUI
+
+```bash
+plotinator-gui
+```
+
+- Edit fits, datasets, styling, and preprocessing steps using a friendly interface.
+- Save changes back to disk through the schema layer.
+- Kick off batch runs directly from the GUI, watching live logs in the sidebar.
+
+### Generate a PDF report
+
+```bash
+plotinator-report
+```
+
+- Consumes the most recent `fit_results.json` emitted by the engine.
+- Builds a Markdown narrative and exports a PDF using Pandoc + wkhtmltopdf.
+
+## Architecture Overview
 
 ```
 Plotinator_10k/
-├── config.json              # Example configuration stub consumed by the GUI & runner
-├── plot_manager.py          # Core batch orchestration, gnuplot code generation, residual analysis
-├── plotinator10000.py       # Tk/ttkbootstrap desktop application for editing configs and launching runs
-├── generate_pdf.py          # Markdown → PDF report pipeline using pypandoc
-├── plotinator/              # Package directory (currently only style helpers)
-│   └── config/style.py      # StyleConfig dataclass with validation & gnuplot legend helpers
-├── data/                    # Placeholder for input datasets (not tracked)
-└── outputs/                 # Target folder for generated plots, logs, reports
+├── engine/                 # Batch runner, data preparation, gnuplot orchestration
+├── config/                 # Schema models, validation helpers, serialization utilities
+├── plotinator/             # Package metadata and shared configuration helpers
+├── plot_manager.py         # CLI entry point that wraps the engine
+├── plotinator10000.py      # ttkbootstrap GUI shell using the schema + engine API
+├── generate_pdf.py         # Markdown/PDF report pipeline
+├── config.json             # Example configuration demonstrating multi-dataset fits
+└── outputs/                # Generated artefacts (plots, residuals, reports)
 ```
 
-## Data & execution flow (current prototype)
+Each layer communicates through clear interfaces:
 
-1. **Configuration** – Users edit `config.json` either manually or via the GUI. Each fit entry describes datasets, layout, style, gnuplot formula, and optional residual analysis settings.
-2. **Batch run** – The runner (currently invoked programmatically) iterates through each fit, writes a gnuplot script, executes it, saves plots + logs, and aggregates metadata/metrics into `fit_results.json`.
-3. **Reporting** – `generate_pdf.py` consumes the JSON results, writes a Markdown report, and invokes Pandoc to export a PDF. The GUI’s “Open report” button will eventually surface the most recent artefact to the operator.
+- `config.PlotinatorConfig` models the entire job and exposes `.to_engine_payload()` for execution.
+- `engine.run_batch()` accepts paths or schema objects and returns structured results for downstream
+  consumers (GUI, reports, tests).
+- `generate_pdf` reads the engine output JSON and focuses solely on documentation concerns.
 
-## Next implementation steps
+## Development Notes
 
-* Promote the batch runner to a first-class CLI command (e.g., `python -m plotinator.runner config.json`) with options for output directories and parallel workers.
-* Finish wiring the GUI buttons to actual runner invocations and progress updates, including graceful cancellation and error surfaces.
-* Add schema validation for the configuration (consider `pydantic` or `jsonschema`) and document expected fields.
-* Implement automated tests for gnuplot code generation, residual computations, and GUI configuration handling (headless-friendly).
-* Introduce a packaging manifest (`pyproject.toml`) with console scripts for the runner and GUI, alongside reproducible environment tooling (e.g., `uv`, `pip-tools`, or `poetry`).
+1. Create a virtual environment and install the project with development extras:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -e .[dev]
+   ```
+2. Ensure `gnuplot`, `pandoc`, and `wkhtmltopdf` are installed locally before exercising the batch
+   pipeline or PDF exporter.
+3. Use `ruff` for linting and `pytest` as tests are added.
 
-## Dependency checklist for packaging & installation
+## Release Process
 
-The following dependencies have already been used in the repository and should be captured when we formalise packaging:
+1. Update `CHANGELOG.md` and bump the version in `pyproject.toml` (mirrored by
+   `plotinator.__version__`).
+2. Run the smoke tests or demo configuration to ensure CLI, GUI, and reporting still interoperate.
+3. Build the distribution:
+   ```bash
+   python -m build
+   ```
+4. Publish to your artefact repository of choice (PyPI, internal index, etc.).
 
-### Python runtime
+## License
 
-* Python 3.11+ (uses `typing.Annotated` style hints and modern standard-library features).
-
-### Python packages
-
-* `numpy` – numerical operations for residual/parameter calculations in `plot_manager.py`.
-* `ttkbootstrap` – themed widgets for the Tkinter GUI.
-* `pypandoc` – wrapper around Pandoc used for Markdown→PDF conversion.
-* Potential future helpers to evaluate: `jsonschema`/`pydantic` (config validation), `typer`/`click` (CLI), `pytest` (testing). These are not yet imported but recommended for the roadmap.
-
-### System requirements
-
-* **gnuplot** – must be installed and available on `PATH`; the runner emits `.plt` scripts and executes them via `subprocess`.
-* **Pandoc** – required by `pypandoc`; can be discovered through `PANDOC_PATH` or system `PATH`.
-* **wkhtmltopdf** – PDF engine used by `generate_pdf.py` for Pandoc conversions.
-* **Ghostscript** (optional) – improves PDF font embedding during conversion, recommended for production pipelines.
-
-Documenting these dependencies now will make it easier to assemble installers, Docker images, or CI workflows later.
-
-## Development tips
-
-* When iterating on the GUI, use a virtual environment with the dependencies installed (`pip install numpy ttkbootstrap pypandoc`). The standard Tkinter module ships with CPython on most platforms.
-* `gnuplot` and `wkhtmltopdf` are external tools; ensure they are on your system `PATH` before running batch jobs or PDF exports.
-* The batch runner writes temporary scripts and logs to each fit’s working directory. Inspect `outputs/<timestamp>/log.txt` when diagnosing failures.
-* Keep the `outputs/` directory in `.gitignore` (already the case) to avoid committing generated artefacts.
-
-Stay tuned—once packaging is in place we will provide a single command to install Plotinator 10k and run both the GUI and automated batch workflows.
+Plotinator 10k is distributed under the terms of the MIT License. See [LICENSE](LICENSE) for
+additional details.

--- a/plotinator/__init__.py
+++ b/plotinator/__init__.py
@@ -1,0 +1,12 @@
+"""Top-level package metadata for Plotinator 10k."""
+
+from __future__ import annotations
+
+from importlib import metadata as _metadata
+
+__all__ = ["__version__"]
+
+try:
+    __version__ = _metadata.version("plotinator-10k")
+except _metadata.PackageNotFoundError:  # pragma: no cover - fallback for local runs
+    __version__ = "0.1.0"

--- a/plotinator10000.py
+++ b/plotinator10000.py
@@ -600,6 +600,11 @@ class DatasetDialog(ttkb.Toplevel):
         toast.after(2500, toast.destroy)
 
 
-if __name__ == "__main__":
+def main() -> int:
     app = PlotinatorApp()
     app.mainloop()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,62 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "plotinator-10k"
+version = "0.1.0"
+description = "Batch plotting, reporting, and GUI tooling for gnuplot-driven curve fits"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {file = "LICENSE"}
+authors = [
+    {name = "Plotinator Labs"}
+]
+keywords = ["gnuplot", "visualization", "curve fitting", "reports", "tkinter"]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Intended Audience :: Science/Research",
+    "Topic :: Scientific/Engineering :: Visualization"
+]
+dependencies = [
+    "numpy>=1.24",
+    "ttkbootstrap>=1.10",
+    "pypandoc>=1.10"
+]
+
+[project.optional-dependencies]
+yaml = ["pyyaml>=6.0"]
+dev = [
+    "pytest>=7.4",
+    "ruff>=0.2"
+]
+
+[project.urls]
+Homepage = "https://github.com/plotinator-labs/Plotinator_10k"
+Repository = "https://github.com/plotinator-labs/Plotinator_10k"
+
+[project.scripts]
+plotinator-cli = "plot_manager:main"
+plotinator-gui = "plotinator10000:main"
+plotinator-report = "generate_pdf:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = [
+    "engine",
+    "config",
+    "plotinator",
+]
+
+[tool.setuptools]
+py-modules = [
+    "plot_manager",
+    "plotinator10000",
+    "generate_pdf",
+]
+
+[tool.ruff]
+select = ["E", "F", "I", "B"]
+line-length = 100


### PR DESCRIPTION
## Summary
- add a pyproject manifest with console scripts, dependencies, and optional extras for packaging
- introduce package metadata (CHANGELOG and plotinator.__version__) and refresh the README for the new architecture
- expose a GUI entry point via plotinator10000.main to support console scripts

## Testing
- python -m compileall engine config plotinator plot_manager.py plotinator10000.py generate_pdf.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910427def4483288121f089fa3f1051)