### PR TITLE
Improve release metadata handling and dev tooling

### DIFF
--- a/plotinator/__init__.py
+++ b/plotinator/__init__.py
@@ -2,11 +2,21 @@
 
 from __future__ import annotations
 
+import re
 from importlib import metadata as _metadata
+from pathlib import Path
 
 __all__ = ["__version__"]
 
 try:
     __version__ = _metadata.version("plotinator-10k")
 except _metadata.PackageNotFoundError:  # pragma: no cover - fallback for local runs
-    __version__ = "0.1.0"
+    _fallback = "0.0.0"
+    pyproject_path = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    try:
+        text = pyproject_path.read_text(encoding="utf-8")
+    except OSError:
+        __version__ = _fallback
+    else:
+        match = re.search(r'^version\s*=\s*"(?P<version>[^"\n]+)"', text, re.MULTILINE)
+        __version__ = match.group("version") if match else _fallback

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,8 @@ dependencies = [
 yaml = ["pyyaml>=6.0"]
 dev = [
     "pytest>=7.4",
-    "ruff>=0.2"
+    "ruff>=0.2",
+    "build>=1.2.1"
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- resolve the missing build dependency in the dev extra so the release instructions work without additional manual installs
- make the package version fallback parse `pyproject.toml` when importlib metadata is unavailable, keeping local runs in sync with the declared version

## Testing
- python -c "import plotinator; print(plotinator.__version__)"
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910664531a8832881d589253b2eaddd)