### PR TITLE
Drain batch stdout after stop signal

### DIFF
--- a/plotinator10000.py
+++ b/plotinator10000.py
@@ -588,7 +588,7 @@ class DatasetDialog(ttkb.Toplevel):
                 self._runner_process = process
                 for line in process.stdout:
                     if self._stop_log.is_set():
-                        break
+                        continue
                     self._append_log(line)
                 process.wait()
                 self.progress.configure(value=100)


### PR DESCRIPTION
## Summary
- continue draining the batch runner stdout even after a stop signal so the subprocess cannot block on a full pipe

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910f45638f88328a50d07a5b2bf67b9)