### PR TITLE
Use engine runner events in GUI batch execution

### DIFF
--- a/engine/runner.py
+++ b/engine/runner.py
@@ -242,7 +242,16 @@ def process_plot(
         "confidence_notes": confidence_notes,
     }
 
-    print(f"[OK] Finished: {plot_cfg['title']}")
+    if dispatcher:
+        dispatcher.emit(
+            "plot-complete",
+            title=result.get("title", "Untitled"),
+            output_plot=result.get("output_plot"),
+            residuals_plot=result.get("residuals_plot"),
+            result=result,
+        )
+    else:
+        print(f"[OK] Finished: {plot_cfg['title']}")
     return result
 
 


### PR DESCRIPTION
## Summary
- run batch jobs through `engine.run_batch` from a background thread and feed its structured events into the GUI
- add a visible status label and react to engine lifecycle events to keep progress reporting in sync
- surface batch exceptions through message boxes and log entries to preserve user feedback
- emit `plot-complete` events after each successful plot so GUI progress counters update correctly

## Testing
- python -m compileall plotinator10000.py
- python -m compileall plotinator10000.py engine/runner.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910f65334f083288abffbfa1531a953)