### PR TITLE
Use dev extras for CI linting and packaging

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,17 +23,24 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: "3.10"
+    - name: Cache pip
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
+        pip install .[dev]
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with flake8
+    - name: Lint with ruff
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        ruff check .
     - name: Test with pytest
       run: |
         pytest
+    - name: Build package
+      run: |
+        python -m build


### PR DESCRIPTION
## Summary
- install the project with development extras so ruff and build tooling are available in CI
- add pip caching, replace flake8 linting with ruff, and include a packaging smoke test

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910f6ee5bf083288ad2999ee255f8e9)