### PR TITLE
Fix runner imports for config normalization

### DIFF
--- a/engine/runner.py
+++ b/engine/runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import datetime
+import json
 import os
 import subprocess
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -13,6 +14,7 @@ from reports.pdf_exporter import export_pdf
 from pathlib import Path
 
 from config import ConfigError, load_config_file
+from .config import normalize_plots
 from .data_pipeline import prepare_datafile
 from .script_builder import (
     compute_residual_metrics,


### PR DESCRIPTION
## Summary
- import json for run_batch config loading
- import normalize_plots from engine.config for run_job usage

## Testing
- python - <<'PY'
from engine import runner

def fake_process_plot(plot_cfg, base_output, dispatcher):
    if dispatcher:
        dispatcher.emit("plot-start", title=plot_cfg.get("title", "Untitled"))
        dispatcher.emit("plot-complete", title=plot_cfg.get("title", "Untitled"))
    return {
        "title": plot_cfg.get("title"),
        "output_plot": None,
    }

runner.process_plot = fake_process_plot


events = []

def capture(event):
    events.append(event["type"])

result = runner.run_batch("config.json", max_workers=1, on_event=capture)
print("events:", events[:5])
print("result keys:", sorted(result.keys()))
PY

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910f8b56b208328897c342c29dd50a6)