### PR TITLE
Refine batch runner configuration handling

### DIFF
--- a/engine/runner.py
+++ b/engine/runner.py
@@ -11,8 +11,6 @@ from typing import Any, Callable, Dict
 from reports.markdown_builder import write_markdown_report
 from reports.pdf_exporter import export_pdf
 
-from pathlib import Path
-
 from config import ConfigError, load_config_file
 from .config import normalize_plots
 from .data_pipeline import prepare_datafile
@@ -248,25 +246,6 @@ def process_plot(
     return result
 
 
-def run_batch(config_path: str, *, max_workers: int = 4) -> dict[str, Any]:
-    try:
-        job = load_config_file(config_path)
-    except ConfigError as exc:
-        raise RuntimeError(str(exc)) from exc
-
-    if job.settings.max_workers:
-        max_workers = job.settings.max_workers
-
-    plots = job.to_engine_payload()
-
-    ts = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    output_root = job.settings.output_dir or Path("outputs").resolve()
-    output_root = Path(output_root)
-    base_output_path = (output_root / ts).resolve()
-    os.makedirs(base_output_path, exist_ok=True)
-    base_output = str(base_output_path)
-
-
 def run_job(
     config: dict,
     *,
@@ -368,12 +347,28 @@ def run_batch(
     max_workers: int = 4,
     on_event: Callable[[dict[str, Any]], None] | None = None,
 ) -> dict[str, Any]:
-    with open(config_path, "r", encoding="utf-8") as f:
-        cfg = json.load(f)
+    try:
+        job = load_config_file(config_path)
+    except ConfigError as exc:
+        raise RuntimeError(str(exc)) from exc
+
+    try:
+        with open(config_path, "r", encoding="utf-8") as handle:
+            config_payload = json.load(handle)
+    except json.JSONDecodeError:
+        config_payload = job.to_dict()
+
+    if job.settings.max_workers:
+        max_workers = job.settings.max_workers
+
+    output_dir: str | None = None
+    if job.settings.output_dir:
+        output_dir = str(job.settings.output_dir)
 
     return run_job(
-        cfg,
+        config_payload,
         config_path=config_path,
         max_workers=max_workers,
+        output_dir=output_dir,
         on_event=on_event,
     )


### PR DESCRIPTION
## Summary
- remove the redundant batch runner implementation in favour of the shared run_job code path
- ensure run_batch loads configuration data via the schema loader while still supporting raw JSON files
- keep run_job emitting report artifacts with the imported helpers

## Testing
- python - <<'PY'
from engine.runner import run_batch

triggered = {"raised": False}

events = []

def on_event(event):
    events.append(event["type"])
    if event["type"] == "job-start" and not triggered["raised"]:
        triggered["raised"] = True
        raise RuntimeError("dry-run-stop")

try:
    run_batch("config.json", max_workers=1, on_event=on_event)
except RuntimeError as exc:
    print(f"caught: {exc}")

print(events)
PY

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910fa66c7dc83288141c13fb6233467)