### PR TITLE
Add PyInstaller spec and Windows MSI packaging assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ MANIFEST
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
+!packaging/plotinator.spec
 
 # Installer logs
 pip-log.txt

--- a/README.md
+++ b/README.md
@@ -108,7 +108,14 @@ Each layer communicates through clear interfaces:
    ```bash
    python -m build
    ```
-   For a frozen Windows build and MSI installer, follow the [Installer Guide](docs/INSTALLER.md).
+   - Windows packaging requires the external binaries (`gnuplot`, `pandoc`, `wkhtmltopdf`) to be installed locally. Export their
+     paths via `GNUPLOT_PATH`, `PANDOC_PATH`, and `WKHTMLTOPDF_PATH` before freezing the app.
+   - Run `pyinstaller packaging/plotinator.spec --clean --noconfirm` to produce the CLI, GUI, and report executables under
+     `dist/plotinator-bundle`. Smoke-test `plotinator-cli.exe`, `plotinator-gui.exe`, and `plotinator-report.exe` in place to
+     ensure they launch and detect the bundled `external/` dependencies.
+   - Harvest the bundle with the WiX Toolset using the assets under `packaging/windows/` and create the MSI as documented in the
+     [Installer Guide](docs/INSTALLER.md). Install the MSI on a clean VM to verify the GUI can run a sample batch and export a PDF
+     report.
 4. Publish to your artefact repository of choice (PyPI, internal index, etc.).
 
 ## Packaging Troubleshooting

--- a/docs/INSTALLER.md
+++ b/docs/INSTALLER.md
@@ -1,128 +1,109 @@
 # Plotinator 10k Installer Guide
 
-This guide walks through building a frozen desktop bundle with [PyInstaller](https://pyinstaller.org/) and wrapping that bundle in a Windows `.msi` installer for beta distribution.
+This guide describes how to freeze the Plotinator 10k toolkit with [PyInstaller](https://pyinstaller.org/) and how to wrap the
+resulting bundle in a Windows `.msi` installer using the [WiX Toolset](https://wixtoolset.org/). Follow the steps in order on a
+Windows machine so that native dependencies are captured correctly.
 
-> **Tip:** Always run the commands from a clean checkout on Windows to guarantee you are bundling the correct platform binaries.
+> **Tip:** Always start from a clean checkout on the target platform. PyInstaller in particular embeds the Python runtime and
+> system DLLs that are present when you build.
 
-## Prerequisites
+## 1. Prerequisites
 
-1. **Python** – install Python 3.10 or newer and ensure `python` is available in your `PATH`.
-2. **Project dependencies** – the GUI requires the same native tools as the CLI:
+1. **Python** – Install Python 3.10 or newer and ensure `python`/`pip` resolve from the terminal.
+2. **Runtime tooling** – Install the external binaries that Plotinator shells out to during execution:
    - [`gnuplot`](http://www.gnuplot.info/)
    - [`pandoc`](https://pandoc.org/)
    - [`wkhtmltopdf`](https://wkhtmltopdf.org/)
-3. **Packaging toolchain**
-   - [PyInstaller](https://pyinstaller.org/) 6.x
-   - [`pyinstaller-hooks-contrib`](https://github.com/pyinstaller/pyinstaller-hooks-contrib)
-   - [WiX Toolset 3.14+](https://wixtoolset.org/) (provides `heat.exe`, `candle.exe`, and `light.exe` for MSI authoring)
-
-Install the Python dependencies inside a virtual environment so the build is reproducible:
-
-```powershell
-python -m venv .venv
-.\.venv\Scripts\activate
-python -m pip install --upgrade pip wheel
-python -m pip install .[yaml]
-python -m pip install pyinstaller pyinstaller-hooks-contrib
-```
-
-## Build the PyInstaller bundle
-
-1. From the repository root, generate a spec file that freezes the GUI entry point and includes the project packages:
+   Export their locations as environment variables before packaging so the PyInstaller spec can pick them up:
    ```powershell
-   pyinstaller plotinator10000.py `
-     --name Plotinator10k `
-     --windowed `
-     --onedir `
-     --noconfirm `
-     --collect-submodules plotinator `
-     --collect-submodules engine `
-     --collect-submodules config `
-     --add-data "config;config" `
-     --add-data "engine;engine" `
-     --add-data "plotinator;plotinator"
+   setx GNUPLOT_PATH "C:\\Program Files\\gnuplot\\bin\\gnuplot.exe"
+   setx PANDOC_PATH "C:\\Program Files\\Pandoc\\pandoc.exe"
+   setx WKHTMLTOPDF_PATH "C:\\Program Files\\wkhtmltopdf\\bin\\wkhtmltopdf.exe"
    ```
-   The command creates `Plotinator10k.spec` and a first build inside `dist/Plotinator10k/`.
-2. Re-run PyInstaller against the generated spec to ensure deterministic rebuilds:
+   Restart the terminal session after updating `setx` values.
+3. **Python dependencies** – Install project extras alongside PyInstaller in an isolated environment:
    ```powershell
-   pyinstaller Plotinator10k.spec --clean --noconfirm
+   python -m venv .venv
+   .\.venv\Scripts\activate
+   python -m pip install --upgrade pip wheel
+   python -m pip install .[yaml]
+   python -m pip install pyinstaller pyinstaller-hooks-contrib
    ```
-3. Verify the bundle:
-   - Executable: `dist\Plotinator10k\Plotinator10k.exe`
-   - Supporting files: `dist\Plotinator10k\contents\*`
-   - Log: `build\Plotinator10k\warn-Plotinator10k.txt` (should be empty)
+4. **WiX Toolset** – Download WiX 3.14+ and either add `%WIX%\bin` to `PATH` or reference the absolute binary paths when running
+   `heat.exe`, `candle.exe`, and `light.exe`.
 
-> **Linux/macOS note:** Replace each `;` in the `--add-data` arguments with `:` when building on non-Windows hosts.
+## 2. Build the PyInstaller bundle
 
-## Wrap the MSI installer
+The repository ships with a tailored spec at `packaging/plotinator.spec` that produces all three entry points (CLI, GUI, and report
+helper) in a single folder.
 
-1. Capture the version number so it can be injected into the installer metadata:
+1. From the repository root, run PyInstaller against the spec:
    ```powershell
-   $PLOTINATOR_VERSION = (python -c "import plotinator; print(plotinator.__version__)").Trim()
+   pyinstaller packaging/plotinator.spec --clean --noconfirm
    ```
-2. Harvest the PyInstaller output into a WiX source file using `heat.exe`:
+2. Inspect the output under `dist\plotinator-bundle` and confirm that it contains:
+   - `plotinator-cli.exe`
+   - `plotinator-gui.exe`
+   - `plotinator-report.exe`
+   - A `data\` folder with the sample `.dat` files
+   - An `external\` folder with the detected `gnuplot`, `pandoc`, and `wkhtmltopdf` executables
+3. Smoke-test the executables before proceeding:
    ```powershell
-   New-Item -ItemType Directory -Force -Path installer | Out-Null
-   "%WIX%\bin\heat.exe" dir dist\Plotinator10k `
+   .\dist\plotinator-bundle\plotinator-cli.exe --help
+   .\dist\plotinator-bundle\plotinator-report.exe --help
+   Start-Process .\dist\plotinator-bundle\plotinator-gui.exe
+   ```
+   Verify that `plotinator-gui.exe` launches, loads `config.json`, and can exit cleanly. If any tool fails to start, double-check
+   that the corresponding external binary is present inside `dist\plotinator-bundle\external` and rebuild if necessary.
+
+## 3. Author the MSI installer
+
+MSI authoring assets live under `packaging/windows/`. The folder contains a WiX template (`plotinator.wxs`) and documentation for
+collecting files from the PyInstaller bundle.
+
+1. **Harvest** the PyInstaller output into a component description using WiX `heat`:
+   ```powershell
+   $bundle = Resolve-Path dist/plotinator-bundle
+   New-Item -ItemType Directory -Force -Path packaging/windows/build | Out-Null
+   heat dir $bundle `
      -dr APPLICATIONFOLDER `
-     -cg Plotinator10kComponents `
+     -cg PlotinatorBundleComponents `
      -gg `
      -sfrag `
      -srd `
-     -out installer\Plotinator10k-files.wxs
+     -out packaging/windows/build/plotinator-files.wxs
    ```
-   - `APPLICATIONFOLDER` becomes the default installation directory under `Program Files`.
-   - The resulting `Plotinator10k-files.wxs` lists all files generated by PyInstaller.
-3. Create (or update) an installer definition that references the harvested component group, for example `installer\Plotinator10k.wxs`:
-   ```xml
-   <?xml version="1.0" encoding="UTF-8"?>
-   <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-     <Product Id="*"
-              Name="Plotinator 10k"
-              Manufacturer="Plotinator Labs"
-              Version="$(var.PLOTINATOR_VERSION)"
-              UpgradeCode="PUT-YOUR-STATIC-UPGRADE-GUID-HERE">
-       <Package InstallerVersion="500"
-                Compressed="yes"
-                InstallScope="perMachine" />
-       <MediaTemplate EmbedCab="yes" />
-       <MajorUpgrade DowngradeErrorMessage="A newer version of Plotinator 10k is already installed." />
-       <Feature Id="MainFeature" Title="Plotinator 10k" Level="1">
-         <ComponentGroupRef Id="Plotinator10kComponents" />
-       </Feature>
-       <UIRef Id="WixUI_InstallDir" />
-       <Property Id="WIXUI_INSTALLDIR" Value="APPLICATIONFOLDER" />
-       <Directory Id="TARGETDIR" Name="SourceDir">
-         <Directory Id="ProgramFilesFolder">
-           <Directory Id="APPLICATIONFOLDER" Name="Plotinator 10k" />
-         </Directory>
-       </Directory>
-     </Product>
-   </Wix>
-   ```
-   Keep the `UpgradeCode` constant across releases.
-4. Compile the WiX sources into an MSI:
+   The generated file is referenced by the template via `<ComponentGroupRef Id="PlotinatorBundleComponents" />`.
+2. **Compile** the WiX sources with the correct version metadata:
    ```powershell
-   "%WIX%\bin\candle.exe" installer\Plotinator10k.wxs installer\Plotinator10k-files.wxs `
-     -dPLOTINATOR_VERSION=$PLOTINATOR_VERSION `
-     -out installer\
-   "%WIX%\bin\light.exe" installer\Plotinator10k.wixobj installer\Plotinator10k-files.wixobj `
+   $version = (python -c "import plotinator; print(plotinator.__version__)").Trim()
+   $wixOut = Resolve-Path packaging/windows/build
+   candle packaging/windows/plotinator.wxs $wixOut/plotinator-files.wxs `
+     -dPLOTINATOR_VERSION=$version `
+     -out $wixOut/
+   ```
+   Replace the placeholder `UpgradeCode` in `plotinator.wxs` with a stable GUID before the first production release.
+3. **Link** the compiled objects into a distributable MSI:
+   ```powershell
+   light $wixOut/plotinator.wixobj $wixOut/plotinator-files.wixobj `
      -ext WixUIExtension `
      -cultures:en-us `
-     -o dist\Plotinator10k-$PLOTINATOR_VERSION.msi
+     -o dist/plotinator-$version.msi
    ```
-5. Expected outputs:
-   - Frozen bundle: `dist\Plotinator10k\Plotinator10k.exe`
-   - Installer artefact: `dist\Plotinator10k-$PLOTINATOR_VERSION.msi`
+4. **Verify** the installer on a clean Windows environment:
+   - Run the MSI and choose the default installation directory.
+   - Confirm the binaries are placed under `Program Files\Plotinator 10k`.
+   - Launch the installed `Plotinator GUI` shortcut and trigger a sample batch run using the bundled `data\` files.
+   - Generate a PDF report via `Plotinator Report Helper` to ensure `pandoc`/`wkhtmltopdf` were correctly captured.
 
-## Packaging Troubleshooting
+## 4. Packaging Troubleshooting
 
 | Symptom | Cause | Resolution |
 | --- | --- | --- |
-| `gnuplot` invocation fails or plots are missing after installation | `gnuplot` is not present on the build machine, so the frozen app cannot bundle the runtime dependency | Install `gnuplot` before running PyInstaller; update `%PATH%` so `gnuplot.exe` resolves. Rebuild the bundle. |
-| PDF report generation crashes with `pandoc: command not found` | Pandoc or `wkhtmltopdf` were absent during packaging | Install both tools and rebuild. Consider adding them to the WiX installer as `Bundle` prerequisites if redistribution is required. |
-| PyInstaller build log reports missing modules such as `plot_manager` or `plotinator.config` | Hidden imports were not collected | Ensure the `pyinstaller` command uses `--collect-submodules` for `plotinator`, `engine`, and `config`. Delete `build/` and `dist/` before rebuilding. |
-| MSI compilation fails with `error LGHT0103 : The system cannot find the file specified` | `heat.exe` output path or `%WIX%` environment variable is incorrect | Confirm the WiX Toolset is installed and `%WIX%\bin` is on `PATH`, or supply the absolute path when running `candle.exe` and `light.exe`. |
-| Installer launches but app immediately exits | Missing runtime DLLs (VC++ redistributable) on the target machine | Install the [Microsoft Visual C++ Redistributable for VS 2015-2022](https://aka.ms/vs/17/release/vc_redist.x64.exe) on the target system. |
+| `gnuplot` invocation fails or plots are missing after installation | `gnuplot` was absent when PyInstaller ran, so the executable was not copied into `external/` | Install `gnuplot`, update `GNUPLOT_PATH`, delete `build/` and `dist/`, then rebuild the PyInstaller bundle. |
+| PDF export crashes with `pandoc: command not found` | `pandoc` or `wkhtmltopdf` were missing when PyInstaller executed | Install both tools, set the corresponding environment variables, and rebuild so the binaries appear in `external/`. |
+| PyInstaller build log reports missing modules such as `plot_manager` | Hidden imports were not collected | Use the provided `packaging/plotinator.spec`; it already collects the `engine`, `config`, `plotinator`, and `reports` packages. Delete previous build artefacts before retrying. |
+| `light.exe` fails with `LGHT0103` (file not found) | Incorrect path to the harvested WiX file or WiX binaries | Ensure `%WIX%` is configured or invoke `heat`, `candle`, and `light` with absolute paths. Verify `packaging/windows/build/plotinator-files.wxs` exists. |
+| Installer launches but the app immediately exits | Missing Visual C++ runtime on the target machine | Install the [Microsoft Visual C++ Redistributable for VS 2015-2022](https://aka.ms/vs/17/release/vc_redist.x64.exe) before running Plotinator. |
 
-Once the MSI is generated, smoke-test the installer on a clean Windows VM before publishing it to beta users.
+Once the MSI passes validation, publish both the zipped `dist/plotinator-bundle` folder and the MSI to your distribution channel.

--- a/packaging/plotinator.spec
+++ b/packaging/plotinator.spec
@@ -1,0 +1,197 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""PyInstaller build specification for Plotinator 10k multi-entry executables."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+from PyInstaller.utils.hooks import collect_submodules
+
+block_cipher = None
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _gather_package_modules(*package_names: str) -> list[str]:
+    """Collect all submodules for the given packages."""
+    modules: set[str] = set()
+    for name in package_names:
+        modules.update(collect_submodules(name))
+    return sorted(modules)
+
+
+common_hiddenimports = _gather_package_modules("engine", "config", "plotinator", "reports")
+
+
+common_datas: list[tuple[str, str]] = []
+
+
+def _add_file(source: Path, target: Path | str) -> None:
+    if not source.is_file():
+        return
+    rel = Path(target)
+    common_datas.append((str(source), rel.as_posix()))
+
+
+def _add_tree(source_dir: Path, target_dir: str) -> None:
+    if not source_dir.is_dir():
+        return
+    for item in source_dir.rglob("*"):
+        if item.is_file():
+            relative = item.relative_to(source_dir)
+            destination = Path(target_dir) / relative
+            common_datas.append((str(item), destination.as_posix()))
+
+
+_add_file(ROOT / "config.json", "config.json")
+_add_tree(ROOT / "data", "data")
+_add_tree(ROOT / "plotinator" / "config", "plotinator/config")
+
+
+common_binaries: list[tuple[str, str]] = []
+
+
+def _add_binary(path: str | None, target_dir: str = "external") -> None:
+    if not path:
+        return
+    candidate = Path(path)
+    if not candidate.exists():
+        return
+    common_binaries.append((str(candidate), Path(target_dir, candidate.name).as_posix()))
+
+
+_add_binary(os.environ.get("GNUPLOT_PATH") or shutil.which("gnuplot"))
+_add_binary(os.environ.get("PANDOC_PATH") or shutil.which("pandoc"))
+_add_binary(os.environ.get("WKHTMLTOPDF_PATH") or shutil.which("wkhtmltopdf"))
+
+
+cli_script = ROOT / "plot_manager.py"
+gui_script = ROOT / "plotinator10000.py"
+report_script = ROOT / "generate_pdf.py"
+
+
+# CLI executable -------------------------------------------------------------
+cli_analysis = Analysis(
+    [str(cli_script)],
+    pathex=[str(ROOT)],
+    binaries=list(common_binaries),
+    datas=list(common_datas),
+    hiddenimports=list(common_hiddenimports),
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+cli_pyz = PYZ(cli_analysis.pure, cli_analysis.zipped_data, cipher=block_cipher)
+cli_exe = EXE(
+    cli_pyz,
+    cli_analysis.scripts,
+    [],
+    exclude_binaries=True,
+    name="plotinator-cli",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+
+# GUI executable -------------------------------------------------------------
+gui_analysis = Analysis(
+    [str(gui_script)],
+    pathex=[str(ROOT)],
+    binaries=list(common_binaries),
+    datas=list(common_datas),
+    hiddenimports=list(common_hiddenimports),
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+gui_pyz = PYZ(gui_analysis.pure, gui_analysis.zipped_data, cipher=block_cipher)
+gui_exe = EXE(
+    gui_pyz,
+    gui_analysis.scripts,
+    [],
+    exclude_binaries=True,
+    name="plotinator-gui",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+
+# Reporting helper executable -----------------------------------------------
+report_analysis = Analysis(
+    [str(report_script)],
+    pathex=[str(ROOT)],
+    binaries=list(common_binaries),
+    datas=list(common_datas),
+    hiddenimports=list(common_hiddenimports),
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+report_pyz = PYZ(report_analysis.pure, report_analysis.zipped_data, cipher=block_cipher)
+report_exe = EXE(
+    report_pyz,
+    report_analysis.scripts,
+    [],
+    exclude_binaries=True,
+    name="plotinator-report",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+
+bundle = COLLECT(
+    cli_exe,
+    gui_exe,
+    report_exe,
+    cli_analysis.binaries,
+    cli_analysis.zipfiles,
+    cli_analysis.datas,
+    gui_analysis.binaries,
+    gui_analysis.zipfiles,
+    gui_analysis.datas,
+    report_analysis.binaries,
+    report_analysis.zipfiles,
+    report_analysis.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name="plotinator-bundle",
+)

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -1,0 +1,43 @@
+# Windows Packaging Assets
+
+This folder contains helper assets for turning the PyInstaller output into a Windows MSI installer.
+
+## Files
+
+- `plotinator.wxs` – WiX authoring template that wraps the PyInstaller bundle. Replace the `UpgradeCode`
+  value with a stable GUID the first time you ship an MSI.
+
+## Usage Overview
+
+1. **Freeze the application** using the shared PyInstaller spec:
+   ```powershell
+   pyinstaller packaging/plotinator.spec --clean --noconfirm
+   ```
+   The output folder `dist\plotinator-bundle` should contain the three executables and resource data.
+2. **Harvest the bundle** into WiX component markup:
+   ```powershell
+   $bundle = Resolve-Path dist/plotinator-bundle
+   New-Item -ItemType Directory -Force -Path packaging/windows/build | Out-Null
+   heat dir $bundle `
+     -dr APPLICATIONFOLDER `
+     -cg PlotinatorBundleComponents `
+     -gg `
+     -sfrag `
+     -srd `
+     -out packaging/windows/build/plotinator-files.wxs
+   ```
+3. **Compile and link** the MSI using the template:
+   ```powershell
+   $version = (python -c "import plotinator; print(plotinator.__version__)").Trim()
+   candle packaging/windows/plotinator.wxs packaging/windows/build/plotinator-files.wxs `
+     -dPLOTINATOR_VERSION=$version `
+     -out packaging/windows/build/
+   light packaging/windows/build/plotinator.wixobj packaging/windows/build/plotinator-files.wixobj `
+     -ext WixUIExtension `
+     -cultures:en-us `
+     -o dist/plotinator-$version.msi
+   ```
+4. **Verify the installer** by running it on a clean Windows VM and checking that the CLI, GUI, and
+   report helpers launch from `Program Files\Plotinator 10k` without missing dependency errors.
+
+For a fuller walkthrough that includes environment setup and validation steps, see `docs/INSTALLER.md`.

--- a/packaging/windows/plotinator.wxs
+++ b/packaging/windows/plotinator.wxs
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  WiX Toolset template for bundling the Plotinator 10k PyInstaller output into an MSI.
+  - Generated component groups from Heat should be emitted to `packaging/windows/plotinator-files.wxs`
+    with the identifier `PlotinatorBundleComponents`.
+  - Inject the project version via the PLOTINATOR_VERSION preprocessor variable when compiling with Candle.
+  - Replace the placeholder UpgradeCode with a stable GUID before shipping your first release.
+-->
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Product Id="*"
+           Name="Plotinator 10k"
+           Manufacturer="Plotinator Labs"
+           Version="$(var.PLOTINATOR_VERSION)"
+           UpgradeCode="00000000-0000-0000-0000-000000000000">
+    <Package InstallerVersion="500"
+             Compressed="yes"
+             InstallScope="perMachine" />
+
+    <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
+    <MajorUpgrade DowngradeErrorMessage="A newer version of Plotinator 10k is already installed." />
+
+    <Property Id="ARPPRODUCTICON" Value="plotinator-gui.exe" />
+    <Property Id="WIXUI_INSTALLDIR" Value="APPLICATIONFOLDER" />
+
+    <UIRef Id="WixUI_InstallDir" />
+
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="ProgramFilesFolder">
+        <Directory Id="APPLICATIONFOLDER" Name="Plotinator 10k" />
+      </Directory>
+    </Directory>
+
+    <Feature Id="MainFeature" Title="Plotinator 10k" Level="1">
+      <ComponentGroupRef Id="PlotinatorBundleComponents" />
+    </Feature>
+  </Product>
+</Wix>


### PR DESCRIPTION
## Summary
- add a shared PyInstaller spec that freezes the CLI, GUI, and report helpers while bundling data files and external tools
- provide a WiX template and usage notes under `packaging/windows/` for MSI creation
- refresh the installer guide and release instructions with detailed build, prerequisite, and verification steps

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910fd64c79c8328987b96258b37417e)