### PR TITLE
Add CLI and reporting tests with coverage configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
 yaml = ["pyyaml>=6.0"]
 dev = [
     "pytest>=7.4",
+    "pytest-cov>=4.1",
     "ruff>=0.2",
     "build>=1.2.1"
 ]
@@ -61,3 +62,7 @@ py-modules = [
 [tool.ruff]
 select = ["E", "F", "I", "B"]
 line-length = 100
+
+[tool.pytest.ini_options]
+addopts = "--cov=plot_manager --cov=reports --cov-report=term-missing"
+testpaths = ["tests"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import pytest
+
+import plot_manager
+
+
+@pytest.mark.parametrize("argv,expected_path", [(["plot_manager.py", "custom.json"], "custom.json"), (["plot_manager.py"], "config.json")])
+def test_main_success(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], argv: list[str], expected_path: str) -> None:
+    """plot_manager.main should delegate to run_batch and return success."""
+
+    call_args: dict[str, str] = {}
+
+    def fake_run_batch(path: str) -> None:
+        call_args["path"] = path
+
+    monkeypatch.setattr(plot_manager, "run_batch", fake_run_batch)
+
+    exit_code = plot_manager.main(argv)
+
+    assert exit_code == 0
+    assert call_args["path"] == expected_path
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_main_missing_config(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    """Missing configuration files should yield an error status and message."""
+
+    def fake_run_batch(path: str) -> None:
+        raise FileNotFoundError(f"{path} does not exist")
+
+    monkeypatch.setattr(plot_manager, "run_batch", fake_run_batch)
+
+    exit_code = plot_manager.main(["plot_manager.py"])  # Default path resolved internally
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "[X]" in captured.out
+    assert "config.json" in captured.out
+
+
+def test_main_handles_unexpected_exceptions(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    """Unexpected exceptions should be surfaced with a non-zero exit code."""
+
+    def fake_run_batch(_: str) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(plot_manager, "run_batch", fake_run_batch)
+
+    exit_code = plot_manager.main(["plot_manager.py", "custom.json"])
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "[X] boom"

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from reports import markdown_builder
+from reports import pdf_exporter
+
+
+def test_load_results_reads_json(tmp_path: Path) -> None:
+    payload = {"timestamp": "2024-01-01", "results": []}
+    results_path = tmp_path / "results.json"
+    results_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    loaded = markdown_builder.load_results(results_path)
+
+    assert loaded == payload
+
+
+def test_build_markdown_document_renders_sections(tmp_path: Path) -> None:
+    output_dir = tmp_path / "report"
+    output_dir.mkdir()
+    assets_dir = output_dir / "assets"
+    assets_dir.mkdir()
+
+    plot_path = assets_dir / "plot.png"
+    plot_path.write_bytes(b"")
+    residual_path = assets_dir / "residuals.png"
+    residual_path.write_bytes(b"")
+
+    results = {
+        "timestamp": "2024-03-15T12:00:00Z",
+        "results": [
+            {
+                "title": "Harmonic Fit",
+                "formula": "A*sin(omega*x) + c",
+                "parameters": {
+                    "A": {"value": 1.23456, "error": 0.02},
+                    "omega": {"value": 0.98765, "error": 0.01},
+                },
+                "metrics": {"mean": 0.1, "std": 0.02, "rmse": 0.03},
+                "data_source": {
+                    "path": str(assets_dir / "data.csv"),
+                    "columns": {"x": 1, "y": 2, "error": 3},
+                    "rows_before": 100,
+                    "rows_after": 95,
+                    "preprocessing": [
+                        {"type": "filter", "expression": "x > 0", "retained_rows": 95},
+                    ],
+                },
+                "confidence_notes": "Stable fit within tolerance.",
+                "output_plot": str(plot_path),
+                "residuals_plot": str(residual_path),
+            }
+        ],
+    }
+
+    markdown = markdown_builder.build_markdown_document(results, output_dir)
+
+    assert "# Plotinator Batch Report" in markdown
+    assert "Harmonic Fit" in markdown
+    assert "Mean = 0.1" in markdown
+    assert "Path: `" in markdown
+    assert "Filter `x > 0`" in markdown
+    assert "![Plot](assets/plot.png)" in markdown
+    assert "![Residuals](assets/residuals.png)" in markdown
+
+
+def test_write_markdown_report_creates_file(tmp_path: Path) -> None:
+    results = {"timestamp": "2024-03-15T12:00:00Z", "results": []}
+    results_path = tmp_path / "results.json"
+    results_path.write_text(json.dumps(results), encoding="utf-8")
+
+    markdown_path = markdown_builder.write_markdown_report(
+        results_path,
+        output_folder=tmp_path / "out",
+        filename="summary.md",
+    )
+
+    assert markdown_path.name == "summary.md"
+    assert markdown_path.parent == tmp_path / "out"
+    assert markdown_path.exists()
+    contents = markdown_path.read_text(encoding="utf-8")
+    assert "# Plotinator Batch Report" in contents
+
+
+@pytest.fixture
+def fake_pandoc(monkeypatch: pytest.MonkeyPatch):
+    calls: list[dict[str, object]] = []
+
+    def ensure() -> str:
+        calls.append({"ensure": True})
+        return "/usr/bin/pandoc"
+
+    def convert_file(source: str, *, to: str, format: str, outputfile: str, extra_args: list[str] | None = None):
+        calls.append(
+            {
+                "source": source,
+                "to": to,
+                "format": format,
+                "outputfile": outputfile,
+                "extra_args": extra_args,
+            }
+        )
+        Path(outputfile).write_text("converted", encoding="utf-8")
+
+    monkeypatch.setattr(pdf_exporter, "ensure_pandoc_available", ensure)
+    monkeypatch.setattr(pdf_exporter.pypandoc, "convert_file", convert_file)
+
+    return calls
+
+
+def test_export_pdf_uses_default_arguments(tmp_path: Path, fake_pandoc: list[dict[str, object]]) -> None:
+    md_path = tmp_path / "report.md"
+    md_path.write_text("Hello", encoding="utf-8")
+
+    pdf_path = pdf_exporter.export_pdf(md_path)
+
+    assert pdf_path == md_path.with_suffix(".pdf").resolve()
+    assert pdf_path.exists()
+
+    ensure_calls = [call for call in fake_pandoc if "ensure" in call]
+    convert_calls = [call for call in fake_pandoc if "source" in call]
+    assert ensure_calls
+    assert convert_calls
+
+    convert_call = convert_calls[0]
+    assert convert_call["source"] == md_path.name
+    assert convert_call["to"] == "pdf"
+    assert convert_call["format"] == "md"
+    assert convert_call["outputfile"] == "report.pdf"
+    assert convert_call["extra_args"] == pdf_exporter.DEFAULT_EXTRA_ARGS["pdf"]
+
+
+def test_export_pdf_respects_custom_output_path(tmp_path: Path, fake_pandoc: list[dict[str, object]]) -> None:
+    md_path = tmp_path / "docs" / "report.md"
+    md_path.parent.mkdir()
+    md_path.write_text("Content", encoding="utf-8")
+
+    output_path = tmp_path / "exports" / "custom-name.pdf"
+
+    pdf_path = pdf_exporter.export_pdf(
+        md_path,
+        output_path=output_path,
+        extra_args=["--metadata", "title=Custom"],
+    )
+
+    assert pdf_path == output_path.resolve()
+    assert output_path.exists()
+
+    convert_calls = [call for call in fake_pandoc if "source" in call]
+    # Last call corresponds to this test invocation
+    convert_call = convert_calls[-1]
+    assert convert_call["source"] == md_path.name
+    assert convert_call["outputfile"] == "report.pdf"
+    assert convert_call["extra_args"] == ["--metadata", "title=Custom"]


### PR DESCRIPTION
## Summary
- add CLI tests that cover success and error paths for `plot_manager.main`
- exercise markdown report builders and PDF exporter with stubbed `pypandoc` calls
- configure pytest to collect coverage for the CLI and reporting modules

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911088921d08328bbb41ddf01849f06)