### PR TITLE
Emit plot completion events

### DIFF
--- a/engine/runner.py
+++ b/engine/runner.py
@@ -242,7 +242,10 @@ def process_plot(
         "confidence_notes": confidence_notes,
     }
 
-    print(f"[OK] Finished: {plot_cfg['title']}")
+    if dispatcher:
+        dispatcher.emit("plot-complete", title=plot_cfg.get("title", "Untitled"))
+    else:
+        print(f"[OK] Finished: {plot_cfg['title']}")
     return result
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -93,6 +93,7 @@ def test_run_job_produces_artifacts(
 
     event_types = {event["type"] for event in events}
     assert {"job-start", "plot-start", "report-exported", "job-complete"}.issubset(event_types)
+    assert any(event["type"] == "plot-complete" for event in events)
 
 
 def test_run_job_handles_pdf_export_error(
@@ -120,3 +121,4 @@ def test_run_job_handles_pdf_export_error(
     pdf_errors = [event for event in events if event["type"] == "report-error"]
     assert pdf_errors and pdf_errors[0]["stage"] == "pdf"
     assert any(event["type"] == "job-complete" for event in events)
+    assert any(event["type"] == "plot-complete" for event in events)


### PR DESCRIPTION
## Summary
- emit a plot-complete event when individual plots finish processing
- adjust plot runner tests to require the completion event in the captured event stream

## Testing
- pytest tests/test_runner.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69110e824ce883288c6432d8f8ca6861)