### PR TITLE
Wrap Python sources to respect 100-character limit

### DIFF
--- a/config/schema.py
+++ b/config/schema.py
@@ -178,7 +178,8 @@ class ColumnMapping:
                 continue
             if value > column_count:
                 raise ConfigError(
-                    f"Data file '{path}' does not have column {value} required for '{context}.{label}'"
+                    "Data file "
+                    f"'{path}' does not have column {value} required for '{context}.{label}'"
                 )
 
     def to_dict(self) -> dict[str, Any]:
@@ -205,7 +206,10 @@ class LayoutConfig:
             value = {}
         data = _load_mapping(value, context=context)
         rows = _ensure_positive(_coerce_int(data.get("rows", 1), 1), field_name=f"{context}.rows")
-        cols = _ensure_positive(_coerce_int(data.get("columns", 1), 1), field_name=f"{context}.columns")
+        cols = _ensure_positive(
+            _coerce_int(data.get("columns", 1), 1),
+            field_name=f"{context}.columns",
+        )
         legend_position = data.get("legend_position")
         if legend_position is not None:
             legend_position = str(legend_position).strip() or None
@@ -261,17 +265,29 @@ class DataSourceConfig:
         preprocessing_raw = data.get("preprocessing")
         preprocessing: list[PreprocessingStep] = []
         if preprocessing_raw is not None:
-            if not isinstance(preprocessing_raw, Iterable) or isinstance(preprocessing_raw, (str, bytes, Mapping)):
+            if not isinstance(preprocessing_raw, Iterable) or isinstance(
+                preprocessing_raw,
+                (str, bytes, Mapping),
+            ):
                 raise ConfigError(f"{context}.preprocessing must be a list")
             for idx, step in enumerate(preprocessing_raw, start=1):
                 preprocessing.append(
                     PreprocessingStep.from_mapping(step, context=f"{context}.preprocessing[{idx}]")
                 )
-        return cls(path=candidate, original_path=raw_path_str, columns=columns, preprocessing=preprocessing)
+        return cls(
+            path=candidate,
+            original_path=raw_path_str,
+            columns=columns,
+            preprocessing=preprocessing,
+        )
 
     def to_dict(self, *, relative_to: Path | None = None) -> dict[str, Any]:
         path_value: str
-        if self.original_path and not Path(self.original_path).is_absolute() and relative_to is not None:
+        if (
+            self.original_path
+            and not Path(self.original_path).is_absolute()
+            and relative_to is not None
+        ):
             try:
                 path_value = os.path.relpath(self.path, relative_to)
             except ValueError:
@@ -398,7 +414,10 @@ class JobSettings:
                 output_path = (base_dir / output_path).resolve()
         max_workers = data.get("max_workers")
         if max_workers is not None:
-            max_workers = _ensure_positive(_coerce_int(max_workers, 1), field_name="settings.max_workers")
+            max_workers = _ensure_positive(
+                _coerce_int(max_workers, 1),
+                field_name="settings.max_workers",
+            )
         return cls(output_dir=output_path, max_workers=max_workers)
 
     def to_dict(self, *, relative_to: Path | None = None) -> dict[str, Any]:
@@ -425,7 +444,13 @@ class FitConfig:
     initial_parameters: dict[str, float] = field(default_factory=dict)
 
     @classmethod
-    def from_mapping(cls, value: Any, *, base_dir: Path, base_style: StyleConfig | None = None) -> "FitConfig":
+    def from_mapping(
+        cls,
+        value: Any,
+        *,
+        base_dir: Path,
+        base_style: StyleConfig | None = None,
+    ) -> "FitConfig":
         data = _load_mapping(value, context="fit")
         title = str(data.get("title") or "Untitled")
         formula = str(data.get("formula") or data.get("fit_formula") or "a*x + b")
@@ -444,7 +469,10 @@ class FitConfig:
                 _apply_style_overrides(style_model, overrides)
         datasets_raw = data.get("datasets")
         datasets: list[DatasetConfig] = []
-        if isinstance(datasets_raw, Iterable) and not isinstance(datasets_raw, (str, bytes, Mapping)):
+        if isinstance(datasets_raw, Iterable) and not isinstance(
+            datasets_raw,
+            (str, bytes, Mapping),
+        ):
             for idx, ds_raw in enumerate(datasets_raw, start=1):
                 datasets.append(
                     DatasetConfig.from_mapping(

--- a/engine/data_pipeline.py
+++ b/engine/data_pipeline.py
@@ -63,7 +63,9 @@ def apply_preprocessing(
                 mask = mask.astype(bool)
             if mask.shape[0] != processed.shape[0]:
                 raise ValueError(
-                    f"Filter expression '{expr}' produced mask of length {mask.shape[0]}, expected {processed.shape[0]}"
+                    "Filter expression "
+                    f"'{expr}' produced mask of length {mask.shape[0]}, "
+                    f"expected {processed.shape[0]}"
                 )
             processed = processed[mask]
             applied.append(
@@ -77,7 +79,8 @@ def apply_preprocessing(
             target_idx = _column_ref_to_index(step["target"])
             if target_idx >= processed.shape[1]:
                 raise ValueError(
-                    f"Transform target column '{step['target']}' (index {target_idx+1}) is out of bounds"
+                    "Transform target column "
+                    f"'{step['target']}' (index {target_idx+1}) is out of bounds"
                 )
             try:
                 values = eval(expr, {"np": np, "math": math}, ctx)
@@ -91,7 +94,9 @@ def apply_preprocessing(
             else:
                 if values.shape[0] != processed.shape[0]:
                     raise ValueError(
-                        f"Transform expression '{expr}' produced {values.shape[0]} rows, expected {processed.shape[0]}"
+                        "Transform expression "
+                        f"'{expr}' produced {values.shape[0]} rows, "
+                        f"expected {processed.shape[0]}"
                     )
                 processed[:, target_idx] = values
             applied.append(

--- a/engine/script_builder.py
+++ b/engine/script_builder.py
@@ -148,7 +148,10 @@ def generate_gnuplot_code(
 
         if include_terminal:
             lines.append(
-                f"set terminal pngcairo size 800,600 font \"{_escape(style_cfg.font_family)},{style_cfg.font_size}\""
+                (
+                    "set terminal pngcairo size 800,600 font "
+                    f"\"{_escape(style_cfg.font_family)},{style_cfg.font_size}\""
+                )
             )
 
         if include_title:
@@ -220,15 +223,23 @@ def generate_gnuplot_code(
         if key in guesses and isinstance(value, (int, float)):
             guesses[key] = float(value)
     init_lines = "\n".join([f"{p} = {guesses.get(p, 1.0)}" for p in params])
-    prints = "\n".join(
-        [
-            (
-                f'if (exists("{p}_err")) {{ print sprintf("PYFIT %s %0.16g %0.16g", "{p}", {p}, {p}_err) }} '
-                f'else {{ print sprintf("PYFIT %s %0.16g %0.16g", "{p}", {p}, 0.0) }}'
-            )
-            for p in params
-        ]
-    )
+    def _format_param_print(name: str) -> str:
+        return "".join(
+            [
+                f'if (exists("{name}_err")) {{ ',
+                (
+                    'print sprintf("PYFIT %s %0.16g %0.16g", '
+                    f'"{name}", {name}, {name}_err) }} '
+                ),
+                "else { ",
+                (
+                    'print sprintf("PYFIT %s %0.16g %0.16g", '
+                    f'"{name}", {name}, 0.0) }}'
+                ),
+            ]
+        )
+
+    prints = "\n".join(_format_param_print(p) for p in params)
 
     fit_using: list[str] = []
     if x_col != 1 or y_col != 2 or err_col or weight_col:
@@ -419,12 +430,13 @@ def generate_gnuplot_code(
         )
         lines.append(f"set output \"{out_res_path}\"")
         lines.append(residual_style)
-        lines.append(
-            (
-                f"plot \"{datafile}\" using {x_col}:(column({y_col}) - f(column({x_col}))) "
-                f"with points pt {pt} title \"Residuals\", \\\n+     0 with lines notitle lc rgb \"gray\""
-            )
-        )
+        residual_plot_parts = [
+            f'plot "{datafile}" using {x_col}:(column({y_col}) - f(column({x_col})))',
+            f'with points pt {pt} title "Residuals", \\',
+            '     0 with lines notitle lc rgb "gray"',
+        ]
+        residual_plot = " ".join(residual_plot_parts[:2]) + "\n" + residual_plot_parts[2]
+        lines.append(residual_plot)
         lines.append("unset output")
 
     return "\n".join(lines)

--- a/plotinator/config/style.py
+++ b/plotinator/config/style.py
@@ -90,7 +90,11 @@ class StyleConfig:
     def from_dict(cls, raw: dict | None, *, fallback_color: str | None = None) -> "StyleConfig":
         if not isinstance(raw, dict):
             raw = {}
-        data = {field.name: raw.get(field.name) for field in cls.__dataclass_fields__.values() if field.init}
+        data = {
+            field.name: raw.get(field.name)
+            for field in cls.__dataclass_fields__.values()
+            if field.init
+        }
 
         if fallback_color and not data.get("line_color"):
             data["line_color"] = fallback_color

--- a/reports/pdf_exporter.py
+++ b/reports/pdf_exporter.py
@@ -40,7 +40,8 @@ def ensure_pandoc_available() -> str:
         return which_path
 
     raise RuntimeError(
-        "Pandoc executable not found. Install Pandoc or set the PANDOC_PATH environment variable to its location."
+        "Pandoc executable not found. Install Pandoc or set the "
+        "PANDOC_PATH environment variable to its location."
     )
 
 
@@ -64,12 +65,20 @@ def export_document(
         out_path = Path(output_path)
         out_path.parent.mkdir(parents=True, exist_ok=True)
 
-    args = list(extra_args) if extra_args is not None else list(DEFAULT_EXTRA_ARGS.get(output_format, []))
+    args = (
+        list(extra_args)
+        if extra_args is not None
+        else list(DEFAULT_EXTRA_ARGS.get(output_format, []))
+    )
 
     cwd = os.getcwd()
     os.chdir(out_dir)
     try:
-        target_name = out_path.name if out_path.parent == out_dir else md_path.with_suffix(f".{output_format}").name
+        target_name = (
+            out_path.name
+            if out_path.parent == out_dir
+            else md_path.with_suffix(f".{output_format}").name
+        )
         pypandoc.convert_file(
             md_path.name,
             to=output_format,

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -94,7 +94,14 @@ def fake_pandoc(monkeypatch: pytest.MonkeyPatch):
         calls.append({"ensure": True})
         return "/usr/bin/pandoc"
 
-    def convert_file(source: str, *, to: str, format: str, outputfile: str, extra_args: list[str] | None = None):
+    def convert_file(
+        source: str,
+        *,
+        to: str,
+        format: str,
+        outputfile: str,
+        extra_args: list[str] | None = None,
+    ):
         calls.append(
             {
                 "source": source,
@@ -112,7 +119,9 @@ def fake_pandoc(monkeypatch: pytest.MonkeyPatch):
     return calls
 
 
-def test_export_pdf_uses_default_arguments(tmp_path: Path, fake_pandoc: list[dict[str, object]]) -> None:
+def test_export_pdf_uses_default_arguments(
+    tmp_path: Path, fake_pandoc: list[dict[str, object]]
+) -> None:
     md_path = tmp_path / "report.md"
     md_path.write_text("Hello", encoding="utf-8")
 
@@ -134,7 +143,9 @@ def test_export_pdf_uses_default_arguments(tmp_path: Path, fake_pandoc: list[dic
     assert convert_call["extra_args"] == pdf_exporter.DEFAULT_EXTRA_ARGS["pdf"]
 
 
-def test_export_pdf_respects_custom_output_path(tmp_path: Path, fake_pandoc: list[dict[str, object]]) -> None:
+def test_export_pdf_respects_custom_output_path(
+    tmp_path: Path, fake_pandoc: list[dict[str, object]]
+) -> None:
     md_path = tmp_path / "docs" / "report.md"
     md_path.parent.mkdir()
     md_path.write_text("Content", encoding="utf-8")

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -18,7 +18,11 @@ def _install_pipeline_stubs(
 ) -> None:
     """Replace external tooling with deterministic fakes for the run pipeline."""
 
-    def fake_generate_gnuplot_code(plot_cfg: dict, out_plot: Optional[str] = None, out_residuals: Optional[str] = None) -> str:
+    def fake_generate_gnuplot_code(
+        plot_cfg: dict,
+        out_plot: Optional[str] = None,
+        out_residuals: Optional[str] = None,
+    ) -> str:
         target = out_plot or out_residuals or "plot"
         return f"# gnuplot script for {target}"
 
@@ -105,7 +109,11 @@ def test_run_job_handles_pdf_export_error(
     """PDF export failures should be reported but not abort the job."""
 
     events: list[dict] = []
-    _install_pipeline_stubs(monkeypatch, sample_paths.output_dir, export_pdf_exception=RuntimeError("pdf unavailable"))
+    _install_pipeline_stubs(
+        monkeypatch,
+        sample_paths.output_dir,
+        export_pdf_exception=RuntimeError("pdf unavailable"),
+    )
 
     result = runner.run_job(
         minimal_config,


### PR DESCRIPTION
## Summary
- reflow long error messages and configuration helpers so wrapped strings honor the 100-character limit
- split plotting helpers and residual export strings to avoid overlong literals while preserving behaviour
- expand test fixtures and PDF exporter helpers to keep definitions and argument handling within the limit

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911692a95748328ba3855186742a9ec)