### PR TITLE
Prep repository for Plotinator Open Beta v1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-beta.1] - 2025-11-10
+### Changed
+- Rebranded the project as Plotinator Open Beta v1.0, including refreshed package metadata and Windows installer assets.
+- Renamed the GUI entry script to `plotinator_gui.py` and updated packaging hooks to reference the new module.
+- Updated README and installer documentation to reflect the open beta release and new installation paths.
+
 ## [0.1.0] - 2024-05-28
 ### Added
 - Initial packaged release of Plotinator 10k with modular engine, configuration schema, and GUI integration.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Plotinator 10k
+# Plotinator Open Beta v1.0
 
-Plotinator 10k is a modular automation toolkit for producing high-quality fitting plots from
+Plotinator Open Beta v1.0 is a modular automation toolkit for producing high-quality fitting plots from
 large batches of experimental datasets. The stack now ships as a Python package with separate
 layers for configuration, execution, user interface, and reporting so each surface can evolve
 independently.
@@ -12,12 +12,18 @@ independently.
 - **Modular engine** – The `engine` package prepares datasets, generates gnuplot scripts, performs
   fits, and aggregates metrics. A thin CLI wrapper keeps scripting simple while enabling programmatic
   reuse.
-- **Desktop GUI** – `plotinator10000.py` provides a ttkbootstrap-powered editor that loads the schema
+- **Desktop GUI** – `plotinator_gui.py` provides a ttkbootstrap-powered editor that loads the schema
   models directly, helping non-technical users manage fits and launch batches without touching JSON.
 - **Reporting pipeline** – `generate_pdf.py` converts engine output into Markdown and PDF artefacts via
   Pandoc, producing narrative-ready reports after each batch run.
 
 ## Installation
+
+```bash
+pip install plotinator-open-beta
+```
+
+To work from a local checkout:
 
 ```bash
 pip install .
@@ -74,7 +80,7 @@ Plotinator_10k/
 ├── config/                 # Schema models, validation helpers, serialization utilities
 ├── plotinator/             # Package metadata and shared configuration helpers
 ├── plot_manager.py         # CLI entry point that wraps the engine
-├── plotinator10000.py      # ttkbootstrap GUI shell using the schema + engine API
+├── plotinator_gui.py       # ttkbootstrap GUI shell using the schema + engine API
 ├── generate_pdf.py         # Markdown/PDF report pipeline
 ├── config.json             # Example configuration demonstrating multi-dataset fits
 └── outputs/                # Generated artefacts (plots, residuals, reports)
@@ -118,27 +124,27 @@ Each layer communicates through clear interfaces:
      report.
 4. Publish to your artefact repository of choice (PyPI, internal index, etc.).
 
-### Beta build retrieval & validation
+### Open beta build retrieval & validation
 
 Tagged builds trigger the **Windows release packaging** workflow, which publishes two artefacts
 under the run's *Artifacts* panel:
 
 - `plotinator-bundle-<tag>` – zipped PyInstaller output from `dist/plotinator-bundle/`.
-- `plotinator-msi-<tag>` – the WiX-generated installer from `dist/`.
+- `plotinator-open-beta-<tag>` – the WiX-generated installer from `dist/`.
 
 To download them, either use the GitHub web UI or fetch via the CLI:
 
 ```bash
 gh run download --repo <org>/Plotinator_10k --name plotinator-bundle-<tag>
-gh run download --repo <org>/Plotinator_10k --name plotinator-msi-<tag>
+gh run download --repo <org>/Plotinator_10k --name plotinator-open-beta-<tag>
 ```
 
 Validate the artefacts before handing them to external testers:
 
 1. Verify file integrity on Windows by computing hashes and comparing against the workflow summary.
    ```powershell
-   Get-FileHash .\plotinator-bundle-<tag>.zip -Algorithm SHA256
-   Get-FileHash .\plotinator-<tag>.msi -Algorithm SHA256
+    Get-FileHash .\plotinator-bundle-<tag>.zip -Algorithm SHA256
+    Get-FileHash .\Plotinator_OpenBeta-<tag>.msi -Algorithm SHA256
    ```
 2. Provision a clean Windows VM (no cached dependencies) and extract the bundle.
    - Launch `plotinator-cli.exe`, `plotinator-gui.exe`, and `plotinator-report.exe` to ensure the
@@ -156,5 +162,5 @@ Common packaging failures and how to recover are documented in the [Installer Gu
 
 ## License
 
-Plotinator 10k is distributed under the terms of the MIT License. See [LICENSE](LICENSE) for
+Plotinator Open Beta v1.0 is distributed under the terms of the MIT License. See [LICENSE](LICENSE) for
 additional details.

--- a/docs/INSTALLER.md
+++ b/docs/INSTALLER.md
@@ -1,6 +1,6 @@
-# Plotinator 10k Installer Guide
+# Plotinator Open Beta v1.0 Installer Guide
 
-This guide describes how to freeze the Plotinator 10k toolkit with [PyInstaller](https://pyinstaller.org/) and how to wrap the
+This guide describes how to freeze the Plotinator Open Beta v1.0 toolkit with [PyInstaller](https://pyinstaller.org/) and how to wrap the
 resulting bundle in a Windows `.msi` installer using the [WiX Toolset](https://wixtoolset.org/). Follow the steps in order on a
 Windows machine so that native dependencies are captured correctly.
 
@@ -88,13 +88,13 @@ collecting files from the PyInstaller bundle.
    light $wixOut/plotinator.wixobj $wixOut/plotinator-files.wixobj `
      -ext WixUIExtension `
      -cultures:en-us `
-     -o dist/plotinator-$version.msi
+     -o dist/Plotinator_OpenBeta-$version.msi
    ```
 4. **Verify** the installer on a clean Windows environment:
    - Run the MSI and choose the default installation directory.
-   - Confirm the binaries are placed under `Program Files\Plotinator 10k`.
-   - Launch the installed `Plotinator GUI` shortcut and trigger a sample batch run using the bundled `data\` files.
-   - Generate a PDF report via `Plotinator Report Helper` to ensure `pandoc`/`wkhtmltopdf` were correctly captured.
+   - Confirm the binaries are placed under `Program Files\Plotinator Open Beta`.
+   - Launch the installed `Plotinator Open Beta GUI` shortcut and trigger a sample batch run using the bundled `data\` files.
+   - Generate a PDF report via `Plotinator Open Beta Report Helper` to ensure `pandoc`/`wkhtmltopdf` were correctly captured.
 
 ## 4. Packaging Troubleshooting
 
@@ -106,4 +106,4 @@ collecting files from the PyInstaller bundle.
 | `light.exe` fails with `LGHT0103` (file not found) | Incorrect path to the harvested WiX file or WiX binaries | Ensure `%WIX%` is configured or invoke `heat`, `candle`, and `light` with absolute paths. Verify `packaging/windows/build/plotinator-files.wxs` exists. |
 | Installer launches but the app immediately exits | Missing Visual C++ runtime on the target machine | Install the [Microsoft Visual C++ Redistributable for VS 2015-2022](https://aka.ms/vs/17/release/vc_redist.x64.exe) before running Plotinator. |
 
-Once the MSI passes validation, publish both the zipped `dist/plotinator-bundle` folder and the MSI to your distribution channel.
+Once the MSI passes validation, publish both the zipped `dist/plotinator-bundle` folder and the `dist/Plotinator_OpenBeta-<version>.msi` package to your distribution channel.

--- a/packaging/plotinator.spec
+++ b/packaging/plotinator.spec
@@ -1,5 +1,5 @@
 # -*- mode: python ; coding: utf-8 -*-
-"""PyInstaller build specification for Plotinator 10k multi-entry executables."""
+"""PyInstaller build specification for Plotinator Open Beta v1.0 multi-entry executables."""
 
 from __future__ import annotations
 
@@ -72,7 +72,7 @@ _add_binary(os.environ.get("WKHTMLTOPDF_PATH") or shutil.which("wkhtmltopdf"))
 
 
 cli_script = ROOT / "plot_manager.py"
-gui_script = ROOT / "plotinator10000.py"
+gui_script = ROOT / "plotinator_gui.py"
 report_script = ROOT / "generate_pdf.py"
 
 

--- a/packaging/windows/README.md
+++ b/packaging/windows/README.md
@@ -35,9 +35,9 @@ This folder contains helper assets for turning the PyInstaller output into a Win
    light packaging/windows/build/plotinator.wixobj packaging/windows/build/plotinator-files.wixobj `
      -ext WixUIExtension `
      -cultures:en-us `
-     -o dist/plotinator-$version.msi
+     -o dist/Plotinator_OpenBeta-$version.msi
    ```
 4. **Verify the installer** by running it on a clean Windows VM and checking that the CLI, GUI, and
-   report helpers launch from `Program Files\Plotinator 10k` without missing dependency errors.
+   report helpers launch from `Program Files\Plotinator Open Beta` without missing dependency errors.
 
 For a fuller walkthrough that includes environment setup and validation steps, see `docs/INSTALLER.md`.

--- a/packaging/windows/build_msi.ps1
+++ b/packaging/windows/build_msi.ps1
@@ -1,13 +1,13 @@
 <#
 .SYNOPSIS
-  Builds the Plotinator 10k MSI installer using WiX v6.
+  Builds the Plotinator Open Beta v1.0 MSI installer using WiX v6.
   Requires wix.exe, Python, and a completed PyInstaller bundle.
 #>
 
 # Stop on errors
 $ErrorActionPreference = 'Stop'
 
-Write-Host "`n=== 🧩 Plotinator 10k MSI Build Script ===`n" -ForegroundColor Cyan
+Write-Host "`n=== 🧩 Plotinator Open Beta v1.0 MSI Build Script ===`n" -ForegroundColor Cyan
 
 # Paths
 $RepoRoot   = (Resolve-Path "$PSScriptRoot\..\..").Path
@@ -20,7 +20,7 @@ $Version    = (python -c "import plotinator; print(plotinator.__version__)").Tri
 New-Item -ItemType Directory -Force -Path $BuildPath | Out-Null
 New-Item -ItemType Directory -Force -Path $OutMSI | Out-Null
 
-Write-Host "Building Plotinator version $Version ..." -ForegroundColor Green
+Write-Host "Building Plotinator Open Beta version $Version ..." -ForegroundColor Green
 
 # 1️⃣ Harvest bundle files into WiX component list
 Write-Host "Harvesting bundle..." -ForegroundColor Yellow
@@ -32,11 +32,11 @@ wix harvest dir $BundlePath `
 # 2️⃣ Build the MSI from WiX sources
 Write-Host "Compiling and linking MSI..." -ForegroundColor Yellow
 wix build `
-    "$RepoRoot\packaging\windows\Product.wxs" `
+    "$RepoRoot\packaging\windows\plotinator.wxs" `
     "$BuildPath\plotinator-files.wxs" `
     -ext WixToolset.UI.wixext `
-    -out "$OutMSI\Plotinator_10k-$Version.msi" `
+    -out "$OutMSI\Plotinator_OpenBeta-$Version.msi" `
     -dPLOTINATOR_VERSION=$Version
 
 Write-Host "`n✅ MSI successfully built:" -ForegroundColor Green
-Write-Host "   $OutMSI\Plotinator_10k-$Version.msi`n" -ForegroundColor Cyan
+Write-Host "   $OutMSI\Plotinator_OpenBeta-$Version.msi`n" -ForegroundColor Cyan

--- a/packaging/windows/plotinator.wxs
+++ b/packaging/windows/plotinator.wxs
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  WiX v6 schema version of the Plotinator 10k installer definition.
+  WiX v6 schema version of the Plotinator Open Beta v1.0 installer definition.
   Build example:
-      wix build Product.wxs plotinator-files.wxs ^
+      wix build plotinator.wxs plotinator-files.wxs ^
            -ext WixToolset.UI.wixext ^
-           -out ..\..\dist\Plotinator_10k.msi ^
+           -out ..\..\dist\Plotinator_OpenBeta.msi ^
            -dPLOTINATOR_VERSION=1.0.0
 -->
 
@@ -12,7 +12,7 @@
 
   <product
       id="*"
-      name="Plotinator 10k"
+      name="Plotinator Open Beta"
       manufacturer="Plotinator Labs"
       version="$(var.PLOTINATOR_VERSION)"
       upgradeCode="PUT-YOUR-STABLE-GUID-HERE-000000000000">
@@ -30,7 +30,7 @@
     <!-- Upgrade logic -->
     <majorUpgrade
         allowDowngrades="no"
-        downgradeErrorMessage="A newer version of Plotinator 10k is already installed." />
+        downgradeErrorMessage="A newer version of Plotinator Open Beta is already installed." />
 
     <!-- Add an application icon (used for Add/Remove Programs entry) -->
     <icon id="AppIcon" sourceFile="plotinator.ico" />
@@ -40,7 +40,7 @@
     <property id="Manufacturer" value="Plotinator Labs" />
     <summaryInformation
         manufacturer="Plotinator Labs"
-        subject="Plotinator 10k Installer"
+        subject="Plotinator Open Beta Installer"
         comments="Automated MSI built with WiX v6" />
 
     <!-- UI -->
@@ -50,12 +50,12 @@
     <!-- Directory structure -->
     <directory id="TARGETDIR" name="SourceDir">
       <directory id="ProgramFiles64Folder">
-        <directory id="APPLICATIONFOLDER" name="Plotinator 10k" />
+        <directory id="APPLICATIONFOLDER" name="Plotinator Open Beta" />
       </directory>
     </directory>
 
     <!-- Features -->
-    <feature id="MainFeature" title="Plotinator 10k" level="1">
+    <feature id="MainFeature" title="Plotinator Open Beta" level="1">
       <componentGroupRef id="PlotinatorBundleComponents" />
     </feature>
 

--- a/plotinator/__init__.py
+++ b/plotinator/__init__.py
@@ -1,4 +1,4 @@
-"""Top-level package metadata for Plotinator 10k."""
+"""Top-level package metadata for Plotinator Open Beta v1.0."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ from pathlib import Path
 __all__ = ["__version__"]
 
 try:
-    __version__ = _metadata.version("plotinator-10k")
+    __version__ = _metadata.version("plotinator-open-beta")
 except _metadata.PackageNotFoundError:  # pragma: no cover - fallback for local runs
     _fallback = "0.0.0"
     pyproject_path = Path(__file__).resolve().parent.parent / "pyproject.toml"

--- a/plotinator_gui.py
+++ b/plotinator_gui.py
@@ -23,7 +23,7 @@ class PlotinatorApp(ttkb.Window):
 
     def __init__(self) -> None:
         super().__init__(themename="superhero")
-        self.title("Plotinator 100000")
+        self.title("Plotinator Open Beta v1.0")
         self.geometry("1200x800")
         self.resizable(True, True)
 
@@ -52,7 +52,7 @@ class PlotinatorApp(ttkb.Window):
             ttkb.Label(header, image=logo).pack(side="left", padx=(0, 10))
         ttkb.Label(
             header,
-            text="⚙️ Plotinator 100000",
+            text="⚙️ Plotinator Open Beta v1.0",
             font=("Segoe UI", 22, "bold"),
         ).pack(side="left")
         ttkb.Button(header, text="🌓", width=3, command=self.toggle_theme).pack(side="right", padx=8)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "plotinator-10k"
-version = "0.1.0"
-description = "Batch plotting, reporting, and GUI tooling for gnuplot-driven curve fits"
+name = "plotinator-open-beta"
+version = "1.0.0b1"
+description = "Open beta release of the Plotinator toolkit for gnuplot-driven curve fits"
 readme = "README.md"
 requires-python = ">=3.10"
 license = {file = "LICENSE"}
@@ -41,7 +41,7 @@ Repository = "https://github.com/plotinator-labs/Plotinator_10k"
 
 [project.scripts]
 plotinator-cli = "plot_manager:main"
-plotinator-gui = "plotinator10000:main"
+plotinator-gui = "plotinator_gui:main"
 plotinator-report = "generate_pdf:main"
 
 [tool.setuptools.packages.find]
@@ -55,7 +55,7 @@ include = [
 [tool.setuptools]
 py-modules = [
     "plot_manager",
-    "plotinator10000",
+    "plotinator_gui",
     "generate_pdf",
 ]
 


### PR DESCRIPTION
## Summary
- rebrand project metadata and docs for the Plotinator Open Beta v1.0 release
- rename the GUI module to `plotinator_gui.py` and update packaging/spec hooks accordingly
- refresh Windows installer assets and guidance with the new product and artifact names

## Testing
- pytest *(fails: pytest: error: unrecognized arguments: --cov=plot_manager --cov=reports --cov-report=term-missing)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691190ac88e0832898785219acbf4374)