### PR TITLE
Guard batch shutdown when destroying window

### DIFF
--- a/plotinator_gui.py
+++ b/plotinator_gui.py
@@ -1162,7 +1162,9 @@ class DatasetDialog(ttkb.Toplevel):
 
     # ------------------------------------------------------------------
     def destroy(self) -> None:  # type: ignore[override]
-        self._stop_runner_thread()
+        stop_runner = getattr(self, "_stop_runner_thread", None)
+        if callable(stop_runner):
+            stop_runner()
         super().destroy()
 
 


### PR DESCRIPTION
## Summary
- guard the batch runner shutdown in PlotinatorApp.destroy so Tk shutdowns without AttributeError

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917a1fb4abc83288529588930f1d4ff)