### PR TITLE
Expose axis windows and ticks in fit editor

### DIFF
--- a/engine/script_builder.py
+++ b/engine/script_builder.py
@@ -188,6 +188,21 @@ def generate_gnuplot_code(
         else:
             lines.append("unset logscale y")
 
+        x_range_clause = style_cfg.axis_range_clause("x")
+        if x_range_clause:
+            lines.append(x_range_clause)
+        else:
+            lines.append("set autoscale x")
+
+        if force_linear_y:
+            lines.append("set autoscale y")
+        else:
+            y_range_clause = style_cfg.axis_range_clause("y")
+            if y_range_clause:
+                lines.append(y_range_clause)
+            else:
+                lines.append("set autoscale y")
+
         if suppress_xtics:
             lines.append("set format x \"\"")
         elif style_cfg.x_tick_format:
@@ -201,6 +216,12 @@ def generate_gnuplot_code(
             lines.append(f"set format y \"{_escape(style_cfg.y_tick_format)}\"")
         else:
             lines.append("set format y")
+
+        lines.append(style_cfg.axis_ticks_clause("x"))
+        if force_linear_y:
+            lines.append("set ytics autofreq")
+        else:
+            lines.append(style_cfg.axis_ticks_clause("y"))
 
         if style_cfg.grid:
             lines.append(f"set grid {style_cfg.grid_layer}")

--- a/plotinator/config/style.py
+++ b/plotinator/config/style.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import ClassVar
+from typing import ClassVar, Mapping, TypeAlias
+
+
+TickEntry: TypeAlias = float | str | tuple[str, float]
+TicksSpec: TypeAlias = tuple[TickEntry, ...] | float | str | None
 
 
 def _coerce_bool(value) -> bool:
@@ -49,11 +54,15 @@ class StyleConfig:
     x_unit: str = ""
     x_scale: str = "linear"
     x_tick_format: str = ""
+    x_window: tuple[float | None, float | None] | None = None
+    x_ticks: TicksSpec = None
 
     y_label: str = "Y"
     y_unit: str = ""
     y_scale: str = "linear"
     y_tick_format: str = ""
+    y_window: tuple[float | None, float | None] | None = None
+    y_ticks: TicksSpec = None
 
     grid: bool = True
     grid_layer: str = "back"
@@ -84,6 +93,10 @@ class StyleConfig:
         self.point_type = _coerce_int(self.point_type, 7)
         self.grid = _coerce_bool(self.grid)
         self.legend_visible = _coerce_bool(self.legend_visible)
+        self.x_window = self._normalize_window(self.x_window)
+        self.y_window = self._normalize_window(self.y_window)
+        self.x_ticks = self._normalize_ticks(self.x_ticks)
+        self.y_ticks = self._normalize_ticks(self.y_ticks)
 
     # ------------------------------------------------------------------
     @classmethod
@@ -109,10 +122,14 @@ class StyleConfig:
             "x_unit": self.x_unit,
             "x_scale": self.x_scale,
             "x_tick_format": self.x_tick_format,
+            "x_window": self._window_to_serializable(self.x_window),
+            "x_ticks": self._ticks_to_serializable(self.x_ticks),
             "y_label": self.y_label,
             "y_unit": self.y_unit,
             "y_scale": self.y_scale,
             "y_tick_format": self.y_tick_format,
+            "y_window": self._window_to_serializable(self.y_window),
+            "y_ticks": self._ticks_to_serializable(self.y_ticks),
             "grid": self.grid,
             "grid_layer": self.grid_layer,
             "legend_visible": self.legend_visible,
@@ -165,4 +182,167 @@ class StyleConfig:
         if mapped == "default":
             return "set key"
         return f"set key {mapped}"
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _normalize_window(
+        value: tuple[float | None, float | None] | Sequence[float | None] | Mapping[str, float | None] | str | float | None,
+    ) -> tuple[float | None, float | None] | None:
+        if value in (None, ""):
+            return None
+
+        lo: float | None = None
+        hi: float | None = None
+
+        if isinstance(value, tuple) and len(value) == 2:
+            lo, hi = value
+        elif isinstance(value, Mapping):
+            lo = StyleConfig._coerce_optional_float(value.get("min"))
+            hi = StyleConfig._coerce_optional_float(value.get("max"))
+        elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+            seq = list(value)
+            if len(seq) >= 1:
+                lo = StyleConfig._coerce_optional_float(seq[0])
+            if len(seq) >= 2:
+                hi = StyleConfig._coerce_optional_float(seq[1])
+        elif isinstance(value, str):
+            parts = [part.strip() for part in value.replace("[", "").replace("]", "").split(",")]
+            if len(parts) >= 1:
+                lo = StyleConfig._coerce_optional_float(parts[0])
+            if len(parts) >= 2:
+                hi = StyleConfig._coerce_optional_float(parts[1])
+        else:
+            try:
+                num = float(value)  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                return None
+            else:
+                lo = num
+        if lo is None and hi is None:
+            return None
+        return (lo, hi)
+
+    @staticmethod
+    def _coerce_optional_float(value: float | str | None) -> float | None:
+        if value in (None, "", "*"):
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _escape_tick_label(label: str) -> str:
+        return label.replace("\\", "\\\\").replace('"', '\"')
+
+    @staticmethod
+    def _normalize_ticks(value: TicksSpec | Sequence | None) -> TicksSpec:  # type: ignore[type-var]
+        if value in (None, ""):
+            return None
+
+        if isinstance(value, (int, float)):
+            return float(value)
+
+        if isinstance(value, str):
+            text = value.strip()
+            if not text or text.lower() in {"auto", "autofreq"}:
+                return None
+            try:
+                return float(text)
+            except ValueError:
+                parts = [part.strip() for part in text.split(",") if part.strip()]
+                if len(parts) > 1:
+                    entries: list[TickEntry] = []
+                    for part in parts:
+                        try:
+                            entries.append(float(part))
+                        except ValueError:
+                            entries.append(part)
+                    return tuple(entries)
+                return text
+
+        if isinstance(value, Sequence):
+            entries: list[TickEntry] = []
+            for item in value:
+                if isinstance(item, Sequence) and not isinstance(item, (str, bytes)):
+                    sub = list(item)
+                    if not sub:
+                        continue
+                    label = str(sub[0])
+                    position = StyleConfig._coerce_optional_float(sub[1] if len(sub) > 1 else None)
+                    if position is None:
+                        try:
+                            position_val = float(sub[0])
+                        except (TypeError, ValueError):
+                            entries.append(label)
+                        else:
+                            entries.append(position_val)
+                    else:
+                        entries.append((label, position))
+                else:
+                    try:
+                        entries.append(float(item))  # type: ignore[arg-type]
+                    except (TypeError, ValueError):
+                        entries.append(str(item))
+            return tuple(entries)
+
+        return None
+
+    @staticmethod
+    def _window_to_serializable(window: tuple[float | None, float | None] | None) -> list[float | None] | None:
+        if window is None:
+            return None
+        return [window[0], window[1]]
+
+    @staticmethod
+    def _ticks_to_serializable(ticks: TicksSpec) -> list | float | str | None:
+        if ticks is None:
+            return None
+        if isinstance(ticks, (int, float, str)):
+            return ticks
+        serialized: list = []
+        for entry in ticks:
+            if isinstance(entry, tuple) and len(entry) == 2:
+                serialized.append([entry[0], entry[1]])
+            else:
+                serialized.append(entry)
+        return serialized
+
+    def axis_window(self, axis: str) -> tuple[float | None, float | None] | None:
+        return self.x_window if axis == "x" else self.y_window
+
+    def axis_range_clause(self, axis: str) -> str | None:
+        window = self.axis_window(axis)
+        if window is None:
+            return None
+        lo, hi = window
+        lo_text = "*" if lo is None else f"{lo:g}"
+        hi_text = "*" if hi is None else f"{hi:g}"
+        return f"set {axis}range [{lo_text}:{hi_text}]"
+
+    def axis_ticks_clause(self, axis: str) -> str:
+        ticks = self.x_ticks if axis == "x" else self.y_ticks
+        prefix = "set xtics" if axis == "x" else "set ytics"
+        if ticks is None:
+            return f"{prefix} autofreq"
+        if isinstance(ticks, (int, float)):
+            if float(ticks) == 0:
+                return f"{prefix} autofreq"
+            return f"{prefix} {float(ticks)}"
+        if isinstance(ticks, str):
+            return f"{prefix} {ticks}"
+        parts: list[str] = []
+        for entry in ticks:
+            if isinstance(entry, tuple) and len(entry) == 2:
+                label, position = entry
+                escaped_label = self._escape_tick_label(str(label))
+                if isinstance(position, (int, float)):
+                    parts.append(f'"{escaped_label}" {position}')
+                else:
+                    parts.append(f'"{escaped_label}" {position}')
+            elif isinstance(entry, (int, float)):
+                parts.append(f"{entry}")
+            else:
+                parts.append(str(entry))
+        return f"{prefix} ({', '.join(parts)})"
 

--- a/plotinator_gui.py
+++ b/plotinator_gui.py
@@ -684,9 +684,11 @@ class PlotinatorApp(ttkb.Window):
             data = fit.to_dict(relative_to=self.job.base_path)
         else:
             data = copy.deepcopy(base)
+        style_data = copy.deepcopy(data.get("style", {})) if isinstance(data.get("style"), dict) else {}
+
         editor = ttkb.Toplevel(self)
         editor.title("Fit details")
-        editor.geometry("620x520")
+        editor.geometry("700x560")
         editor.grab_set()
 
         notebook = ttkb.Notebook(editor)
@@ -694,9 +696,11 @@ class PlotinatorApp(ttkb.Window):
 
         general_tab = ttkb.Frame(notebook, padding=10)
         layout_tab = ttkb.Frame(notebook, padding=10)
+        style_tab = ttkb.Frame(notebook, padding=10)
         datasets_tab = ttkb.Frame(notebook, padding=10)
         notebook.add(general_tab, text="General")
         notebook.add(layout_tab, text="Layout")
+        notebook.add(style_tab, text="Style")
         notebook.add(datasets_tab, text="Datasets")
 
         # General tab --------------------------------------------------
@@ -744,6 +748,96 @@ class PlotinatorApp(ttkb.Window):
         ttkb.Checkbutton(layout_tab, text="Show legend", variable=show_legend).grid(
             row=4, column=0, columnspan=2, sticky="w", padx=5, pady=6
         )
+
+        # Style tab ----------------------------------------------------
+        style_tab.columnconfigure(1, weight=1)
+        style_tab.columnconfigure(3, weight=1)
+
+        def _extract_window_entries(value: object) -> tuple[str, str]:
+            lo_text = ""
+            hi_text = ""
+            if isinstance(value, (list, tuple)):
+                if len(value) > 0 and value[0] not in (None, ""):
+                    lo_text = str(value[0])
+                if len(value) > 1 and value[1] not in (None, ""):
+                    hi_text = str(value[1])
+            elif isinstance(value, dict):
+                if value.get("min") not in (None, ""):
+                    lo_text = str(value.get("min"))
+                if value.get("max") not in (None, ""):
+                    hi_text = str(value.get("max"))
+            elif isinstance(value, str):
+                stripped = value.strip().strip("[]")
+                parts = [part.strip() for part in stripped.split(",") if part.strip()]
+                if parts:
+                    lo_text = parts[0]
+                if len(parts) > 1:
+                    hi_text = parts[1]
+            elif value not in (None, ""):
+                try:
+                    lo_text = str(float(value))
+                except (TypeError, ValueError):
+                    lo_text = str(value)
+            return lo_text, hi_text
+
+        def _format_ticks_value(value: object) -> str:
+            if value in (None, ""):
+                return ""
+            if isinstance(value, (list, tuple, dict)):
+                try:
+                    return json.dumps(value)
+                except TypeError:
+                    return str(value)
+            return str(value)
+
+        style_entries: dict[str, ttkb.Entry] = {}
+
+        ttkb.Label(style_tab, text="X axis window").grid(row=0, column=0, sticky="w", padx=5, pady=6)
+        x_min_entry = ttkb.Entry(style_tab, width=12)
+        x_min_entry.grid(row=0, column=1, sticky="ew", padx=5, pady=6)
+        ttkb.Label(style_tab, text="to").grid(row=0, column=2, sticky="w", padx=5, pady=6)
+        x_max_entry = ttkb.Entry(style_tab, width=12)
+        x_max_entry.grid(row=0, column=3, sticky="ew", padx=5, pady=6)
+        x_lo, x_hi = _extract_window_entries(style_data.get("x_window"))
+        if x_lo:
+            x_min_entry.insert(0, x_lo)
+        if x_hi:
+            x_max_entry.insert(0, x_hi)
+        style_entries["x_window_min"] = x_min_entry
+        style_entries["x_window_max"] = x_max_entry
+
+        ttkb.Label(style_tab, text="Y axis window").grid(row=1, column=0, sticky="w", padx=5, pady=6)
+        y_min_entry = ttkb.Entry(style_tab, width=12)
+        y_min_entry.grid(row=1, column=1, sticky="ew", padx=5, pady=6)
+        ttkb.Label(style_tab, text="to").grid(row=1, column=2, sticky="w", padx=5, pady=6)
+        y_max_entry = ttkb.Entry(style_tab, width=12)
+        y_max_entry.grid(row=1, column=3, sticky="ew", padx=5, pady=6)
+        y_lo, y_hi = _extract_window_entries(style_data.get("y_window"))
+        if y_lo:
+            y_min_entry.insert(0, y_lo)
+        if y_hi:
+            y_max_entry.insert(0, y_hi)
+        style_entries["y_window_min"] = y_min_entry
+        style_entries["y_window_max"] = y_max_entry
+
+        ttkb.Label(style_tab, text="X axis ticks").grid(row=2, column=0, sticky="w", padx=5, pady=6)
+        x_ticks_entry = ttkb.Entry(style_tab)
+        x_ticks_entry.grid(row=2, column=1, columnspan=3, sticky="ew", padx=5, pady=6)
+        x_ticks_entry.insert(0, _format_ticks_value(style_data.get("x_ticks")))
+        style_entries["x_ticks"] = x_ticks_entry
+
+        ttkb.Label(style_tab, text="Y axis ticks").grid(row=3, column=0, sticky="w", padx=5, pady=6)
+        y_ticks_entry = ttkb.Entry(style_tab)
+        y_ticks_entry.grid(row=3, column=1, columnspan=3, sticky="ew", padx=5, pady=6)
+        y_ticks_entry.insert(0, _format_ticks_value(style_data.get("y_ticks")))
+        style_entries["y_ticks"] = y_ticks_entry
+
+        ttkb.Label(
+            style_tab,
+            text="Leave fields blank for automatic ranges/ticks. Use '*' for defaults or JSON lists for custom ticks.",
+            wraplength=480,
+            bootstyle="info",
+        ).grid(row=4, column=0, columnspan=4, sticky="w", padx=5, pady=(6, 0))
 
         # Datasets tab -------------------------------------------------
         dataset_frame = ttkb.Frame(datasets_tab)
@@ -873,7 +967,52 @@ class PlotinatorApp(ttkb.Window):
             payload["datasets"] = copy.deepcopy(dataset_list)
             if data.get("parameters"):
                 payload["parameters"] = copy.deepcopy(data.get("parameters"))
-            style_overrides = copy.deepcopy(data.get("style", {}))
+            style_overrides = copy.deepcopy(style_data)
+
+            def _parse_window(min_key: str, max_key: str, dest_key: str) -> None:
+                min_text = style_entries[min_key].get().strip()
+                max_text = style_entries[max_key].get().strip()
+
+                def _convert(value: str) -> float | None:
+                    if not value or value == "*":
+                        return None
+                    try:
+                        return float(value)
+                    except ValueError:
+                        return None
+
+                if not min_text and not max_text:
+                    style_overrides.pop(dest_key, None)
+                    return
+
+                lo_value = _convert(min_text)
+                hi_value = _convert(max_text)
+                if lo_value is None and hi_value is None:
+                    style_overrides.pop(dest_key, None)
+                else:
+                    style_overrides[dest_key] = [lo_value, hi_value]
+
+            def _parse_ticks(entry_key: str, dest_key: str) -> None:
+                text = style_entries[entry_key].get().strip()
+                if not text:
+                    style_overrides.pop(dest_key, None)
+                    return
+                if text.startswith("[") or text.startswith("{"):
+                    try:
+                        style_overrides[dest_key] = json.loads(text)
+                        return
+                    except json.JSONDecodeError:
+                        pass
+                try:
+                    style_overrides[dest_key] = float(text)
+                except ValueError:
+                    style_overrides[dest_key] = text
+
+            _parse_window("x_window_min", "x_window_max", "x_window")
+            _parse_window("y_window_min", "y_window_max", "y_window")
+            _parse_ticks("x_ticks", "x_ticks")
+            _parse_ticks("y_ticks", "y_ticks")
+
             if payload["color"]:
                 style_overrides.setdefault("line_color", payload["color"])
             if style_overrides:

--- a/tests/test_style_config.py
+++ b/tests/test_style_config.py
@@ -1,0 +1,33 @@
+"""Tests for the StyleConfig helpers."""
+
+from plotinator.config.style import StyleConfig
+
+
+def test_style_config_window_normalization() -> None:
+    cfg = StyleConfig.from_dict(
+        {
+            "x_window": [0, 10],
+            "y_window": {"min": -1, "max": 1},
+        }
+    )
+
+    assert cfg.x_window == (0.0, 10.0)
+    assert cfg.y_window == (-1.0, 1.0)
+    assert cfg.axis_range_clause("x") == "set xrange [0:10]"
+    assert cfg.axis_range_clause("y") == "set yrange [-1:1]"
+    assert cfg.to_dict()["x_window"] == [0.0, 10.0]
+    assert cfg.to_dict()["y_window"] == [-1.0, 1.0]
+
+
+def test_style_config_tick_clauses() -> None:
+    cfg = StyleConfig.from_dict(
+        {
+            "x_ticks": 2,
+            "y_ticks": [["Low", -1], ["High", 1]],
+        }
+    )
+
+    assert cfg.axis_ticks_clause("x") == "set xtics 2.0"
+    assert cfg.axis_ticks_clause("y") == 'set ytics ("Low" -1.0, "High" 1.0)'
+    assert cfg.to_dict()["x_ticks"] == 2.0
+    assert cfg.to_dict()["y_ticks"] == [["Low", -1.0], ["High", 1.0]]


### PR DESCRIPTION
## Summary
- add a style tab to the fit editor so users can configure axis windows and tick definitions
- persist the configured windows and ticks into the fit style overrides when saving the fit

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69181fcdb554832896012073d737e0d1)