### PR TITLE
Add legacy workspace migration utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ plotinator-gui
 - Save changes back to disk through the schema layer.
 - Kick off batch runs directly from the GUI, watching live logs in the sidebar.
 
+### Migrating legacy workspaces
+
+- Opening a folder that only contains a historical `config.json` will automatically create a temporary `.p10k` project in your `%TEMP%/Untitled.p10k` directory.
+- The migration copies data files into the project `data/` folder and splits metadata/settings into the new JSON layout.
+- See [docs/LEGACY_WORKSPACES.md](docs/LEGACY_WORKSPACES.md) for a detailed overview of the schema differences.
+
 ### Generate a PDF report
 
 ```bash

--- a/docs/LEGACY_WORKSPACES.md
+++ b/docs/LEGACY_WORKSPACES.md
@@ -1,0 +1,43 @@
+# Migrating Legacy Plotinator Workspaces
+
+Plotinator versions prior to the project-domain models stored all workspace
+information inside a single `config.json` that lived next to the raw data
+files. The modern format replaces this flat layout with a dedicated `.p10k`
+folder that contains:
+
+* `project.json` – metadata (schema version, label, description).
+* `fits.json` – the list of fits and datasets, separated from the metadata.
+* `settings.json` – execution defaults (export targets, worker count).
+* `data/` – a local copy of every dataset referenced by the project.
+* `plots/` and `exports/` – reserved directories for generated artefacts.
+
+## Schema Changes
+
+The new schema mirrors the data classes inside `plotinator.project.models` and
+`config.schema`:
+
+| Legacy (`config.json`) | Modern (`.p10k`) |
+| ---------------------- | ---------------- |
+| Single JSON document combining metadata, job settings, and fits. | Separate `project.json`, `settings.json`, and `fits.json` files. |
+| Dataset paths interpreted relative to the location of `config.json`. | Dataset paths resolved relative to `<project>/data`. |
+| Original data files stored in-place. | Data files are copied into `<project>/data`, preserving relative references. |
+
+During migration each dataset retains a relative path so that the fits refer to
+the copied files inside the project folder. Absolute references are converted
+to filenames to avoid leaking machine-specific paths.
+
+## Migration Behaviour
+
+* Detecting a loose `config.json` triggers the migration helpers defined in
+  `plotinator.project.migration`.
+* The legacy configuration is converted into a temporary
+  `%TEMP%/Untitled.p10k` project unless another target is specified.
+* Data files referenced by the legacy configuration are copied into the
+  project's `data/` directory, reusing the original relative layout when it is
+  safe to do so.
+* The original `config.json` is left untouched. The migration operates on a
+  copy and writes the new project files to the `.p10k` folder only.
+
+After migrating you can open the generated `.p10k` directory directly in the
+application to continue working with the preserved fits and settings.
+

--- a/plotinator/project/__init__.py
+++ b/plotinator/project/__init__.py
@@ -1,9 +1,21 @@
 """Project model helpers for Plotinator workspaces."""
 
+from .migration import (
+    LEGACY_CONFIG_FILENAME,
+    TEMP_PROJECT_FOLDER,
+    find_legacy_config,
+    migrate_config_file,
+    synthesise_temporary_project,
+)
 from .models import PlotinatorProject, ProjectMetadata, ProjectPaths
 
 __all__ = [
     "PlotinatorProject",
     "ProjectMetadata",
     "ProjectPaths",
+    "LEGACY_CONFIG_FILENAME",
+    "TEMP_PROJECT_FOLDER",
+    "find_legacy_config",
+    "migrate_config_file",
+    "synthesise_temporary_project",
 ]

--- a/plotinator/project/migration.py
+++ b/plotinator/project/migration.py
@@ -1,0 +1,166 @@
+"""Helpers for migrating legacy Plotinator workspaces."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import Iterable
+
+from config.schema import PlotinatorConfig
+from .models import PlotinatorProject, ProjectMetadata, ProjectPaths
+
+LEGACY_CONFIG_FILENAME = "config.json"
+TEMP_PROJECT_FOLDER = "Untitled.p10k"
+
+__all__ = [
+    "LEGACY_CONFIG_FILENAME",
+    "TEMP_PROJECT_FOLDER",
+    "find_legacy_config",
+    "synthesise_temporary_project",
+    "migrate_config_file",
+]
+
+
+def find_legacy_config(location: Path) -> Path | None:
+    """Return the path to a loose ``config.json`` if one is present."""
+
+    candidate = Path(location)
+    if candidate.is_file() and candidate.name == LEGACY_CONFIG_FILENAME:
+        return candidate
+
+    if candidate.is_dir():
+        config_path = candidate / LEGACY_CONFIG_FILENAME
+        project_marker = candidate / "project.json"
+        if config_path.is_file() and not project_marker.exists():
+            return config_path
+
+    return None
+
+
+def synthesise_temporary_project(location: Path, *, temp_root: Path | None = None) -> PlotinatorProject | None:
+    """Create a migrated project for legacy workspaces inside a temp directory."""
+
+    config_path = find_legacy_config(location)
+    if config_path is None:
+        return None
+
+    temporary_root = Path(temp_root) if temp_root is not None else _default_temp_project_root()
+    if temporary_root.exists():
+        shutil.rmtree(temporary_root)
+
+    return migrate_config_file(config_path, temporary_root)
+
+
+def migrate_config_file(path: Path, target: Path) -> PlotinatorProject:
+    """Convert a legacy ``config.json`` into the modern project folder layout."""
+
+    config_path = Path(path)
+    if not config_path.is_file():
+        raise FileNotFoundError(f"Legacy configuration file not found: {config_path}")
+
+    with config_path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    legacy_root = config_path.parent.resolve()
+    config = PlotinatorConfig.from_mapping(payload, base_path=legacy_root)
+
+    workspace_name = legacy_root.name or config_path.stem or "Untitled"
+    metadata = ProjectMetadata(label=workspace_name)
+
+    target_root = Path(target)
+    if target_root.exists():
+        shutil.rmtree(target_root)
+
+    paths = ProjectPaths.from_root(target_root)
+    project = PlotinatorProject(paths=paths, metadata=metadata, config=config)
+
+    _materialise_data_files(project, legacy_root)
+    project.save()
+    return project
+
+
+def _default_temp_project_root() -> Path:
+    return Path(tempfile.gettempdir()) / TEMP_PROJECT_FOLDER
+
+
+def _materialise_data_files(project: PlotinatorProject, legacy_root: Path) -> None:
+    destination = project.paths.data_dir
+    destination.mkdir(parents=True, exist_ok=True)
+
+    copied: set[Path] = set()
+    for fit in project.config.fits:
+        for dataset in fit.datasets:
+            source_path = dataset.data_source.path.resolve()
+            relative_path = _derive_relative_path(dataset.data_source.original_path, source_path, legacy_root)
+            dest_path = destination / relative_path
+            dest_path.parent.mkdir(parents=True, exist_ok=True)
+
+            dest_resolved = dest_path.resolve()
+            if dest_resolved not in copied:
+                if source_path != dest_resolved:
+                    shutil.copy2(source_path, dest_path)
+                else:
+                    dest_path.touch(exist_ok=True)
+                copied.add(dest_resolved)
+
+            dataset.data_source.path = dest_resolved
+            dataset.data_source.original_path = relative_path.as_posix()
+
+
+def _derive_relative_path(original: str, source_path: Path, legacy_root: Path) -> Path:
+    default = Path(source_path.name)
+
+    workspace_candidate = _sanitise_parts(source_path.relative_to(legacy_root).parts) if _is_within_root(source_path, legacy_root) else None
+    if workspace_candidate:
+        trimmed = _trim_legacy_data_prefix(workspace_candidate)
+        if trimmed:
+            return Path(*trimmed)
+
+    original_candidate = _sanitise_original(original)
+    if original_candidate:
+        trimmed = _trim_legacy_data_prefix(original_candidate)
+        if trimmed:
+            return Path(*trimmed)
+
+    return default
+
+
+def _trim_legacy_data_prefix(parts: tuple[str, ...]) -> tuple[str, ...]:
+    if not parts:
+        return parts
+    if parts[0].lower() == "data" and len(parts) > 1:
+        return parts[1:]
+    return parts
+
+
+def _is_within_root(source_path: Path, legacy_root: Path) -> bool:
+    try:
+        source_path.relative_to(legacy_root)
+        return True
+    except ValueError:
+        return False
+
+
+def _sanitise_parts(parts: Iterable[str]) -> tuple[str, ...] | None:
+    cleaned: list[str] = []
+    for part in parts:
+        if not part or part == ".":
+            continue
+        if part == "..":
+            return None
+        cleaned.append(part)
+    return tuple(cleaned)
+
+
+def _sanitise_original(original: str | None) -> tuple[str, ...] | None:
+    if not original:
+        return None
+    windows = PureWindowsPath(original)
+    posix = PurePosixPath(original)
+    if windows.is_absolute() or posix.is_absolute():
+        return None
+    candidate = windows.parts if len(windows.parts) >= len(posix.parts) else posix.parts
+    return _sanitise_parts(candidate)
+

--- a/tests/test_project_migration.py
+++ b/tests/test_project_migration.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from plotinator.project import (
+    PlotinatorProject,
+    find_legacy_config,
+    migrate_config_file,
+    synthesise_temporary_project,
+)
+
+
+@pytest.fixture()
+def legacy_workspace(tmp_path: Path) -> Path:
+    workspace = tmp_path / "legacy"
+    data_dir = workspace / "data"
+    data_dir.mkdir(parents=True)
+    (data_dir / "sample.dat").write_text("1 2\n", encoding="utf-8")
+
+    config_payload = {
+        "settings": {"max_workers": 3},
+        "fits": [
+            {
+                "title": "Legacy Fit",
+                "formula": "a*x + b",
+                "residuals": True,
+                "layout": {
+                    "rows": 1,
+                    "columns": 1,
+                    "shared_x": False,
+                    "shared_y": False,
+                    "show_legend": True,
+                },
+                "datasets": [
+                    {
+                        "label": "Dataset",
+                        "data_source": {
+                            "path": "data/sample.dat",
+                            "columns": {"x": 1, "y": 2},
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+
+    config_path = workspace / "config.json"
+    config_path.write_text(json.dumps(config_payload), encoding="utf-8")
+    return workspace
+
+
+def test_find_legacy_config_from_directory(legacy_workspace: Path) -> None:
+    config_path = find_legacy_config(legacy_workspace)
+    assert config_path == legacy_workspace / "config.json"
+
+    # Add a modern project marker to ensure the helper ignores it.
+    (legacy_workspace / "project.json").write_text("{}", encoding="utf-8")
+    assert find_legacy_config(legacy_workspace) is None
+
+
+def test_migrate_config_file_creates_project_structure(legacy_workspace: Path, tmp_path: Path) -> None:
+    target = tmp_path / "Migrated.p10k"
+    project = migrate_config_file(legacy_workspace / "config.json", target)
+
+    assert project.paths.root == target
+    assert project.paths.metadata.exists()
+    assert project.paths.fits.exists()
+    assert project.paths.settings.exists()
+
+    saved_fits = json.loads(project.paths.fits.read_text(encoding="utf-8"))
+    dataset_payload = saved_fits[0]["datasets"][0]
+    assert dataset_payload["data_source"]["path"] == "sample.dat"
+
+    copied_data = project.paths.data_dir / "sample.dat"
+    assert copied_data.exists()
+
+    reloaded = PlotinatorProject.load(target)
+    dataset = reloaded.config.fits[0].datasets[0]
+    assert dataset.data_source.path == copied_data.resolve()
+    assert dataset.data_source.original_path == "sample.dat"
+
+    # Ensure the original config is untouched.
+    with (legacy_workspace / "config.json").open("r", encoding="utf-8") as handle:
+        original_payload = json.load(handle)
+    assert original_payload["settings"]["max_workers"] == 3
+
+
+def test_synthesise_temporary_project(monkeypatch: pytest.MonkeyPatch, legacy_workspace: Path, tmp_path: Path) -> None:
+    temp_root = tmp_path / "temp"
+    temp_root.mkdir()
+
+    monkeypatch.setattr("plotinator.project.migration._default_temp_project_root", lambda: temp_root / "Untitled.p10k")
+
+    project = synthesise_temporary_project(legacy_workspace)
+    assert project is not None
+    assert project.paths.root == temp_root / "Untitled.p10k"
+    assert project.paths.metadata.exists()
+


### PR DESCRIPTION
## Summary
- add migration helpers to detect legacy config.json workspaces and synthesise a temporary .p10k project
- ensure migration copies dataset files, rewrites configuration payloads, and expose the helpers from the project package
- document schema differences between legacy and modern layouts and cover the migration flow with tests

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691842042af883289795296a6b7d0f59)