### PR TITLE
Add project manager for lifecycle operations

### DIFF
--- a/plotinator/project/__init__.py
+++ b/plotinator/project/__init__.py
@@ -7,12 +7,15 @@ from .migration import (
     migrate_config_file,
     synthesise_temporary_project,
 )
+from .manager import FilesystemCallback, ProjectManager
 from .models import PlotinatorProject, ProjectMetadata, ProjectPaths
 
 __all__ = [
     "PlotinatorProject",
     "ProjectMetadata",
     "ProjectPaths",
+    "ProjectManager",
+    "FilesystemCallback",
     "LEGACY_CONFIG_FILENAME",
     "TEMP_PROJECT_FOLDER",
     "find_legacy_config",

--- a/plotinator/project/manager.py
+++ b/plotinator/project/manager.py
@@ -1,0 +1,255 @@
+"""High-level orchestration helpers for Plotinator project folders."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Callable, Iterable, Sequence
+
+from .migration import synthesise_temporary_project
+from .models import PlotinatorProject, ProjectMetadata, ProjectPaths
+
+
+FilesystemCallback = Callable[[ProjectPaths], None]
+
+
+class ProjectManager:
+    """Coordinate project lifecycle operations and filesystem notifications."""
+
+    def __init__(
+        self,
+        *,
+        filesystem_callbacks: Iterable[FilesystemCallback] | None = None,
+    ) -> None:
+        self._project: PlotinatorProject | None = None
+        self._filesystem_callbacks: list[FilesystemCallback] = (
+            list(filesystem_callbacks) if filesystem_callbacks is not None else []
+        )
+        self._clean_snapshot: str | None = None
+        self._dirty: bool = False
+
+    # ------------------------------------------------------------------
+    # Public API
+
+    def register_filesystem_callback(self, callback: FilesystemCallback) -> None:
+        """Register a callback invoked when project files are materialised."""
+
+        self._filesystem_callbacks.append(callback)
+
+    # Lifecycle ---------------------------------------------------------
+
+    def new_project(
+        self,
+        location: Path | str,
+        *,
+        metadata: ProjectMetadata | None = None,
+    ) -> PlotinatorProject:
+        """Create a new project at ``location`` and persist an empty layout."""
+
+        root = Path(location)
+        paths = ProjectPaths.from_root(root)
+        project = PlotinatorProject(
+            paths=paths,
+            metadata=metadata if metadata is not None else ProjectMetadata(),
+        )
+        project.save()
+        self._set_project(project)
+        self._notify_filesystem()
+        return project
+
+    def open_project(self, location: Path | str) -> PlotinatorProject:
+        """Open an existing project or migrate a legacy workspace."""
+
+        path = Path(location)
+        project = self._load_project(path)
+        self._set_project(project)
+        self._notify_filesystem()
+        return project
+
+    def save_project(self) -> PlotinatorProject:
+        """Persist the current project state to disk."""
+
+        project = self.current_project()
+        project.save()
+        self._update_snapshot()
+        self._notify_filesystem()
+        return project
+
+    def save_project_as(self, location: Path | str) -> PlotinatorProject:
+        """Save the current project to a new root directory."""
+
+        current = self.current_project()
+        target_root = Path(location)
+        new_paths = ProjectPaths.from_root(target_root)
+        config_copy = current.to_config()
+        metadata_copy = ProjectMetadata.from_dict(current.metadata.to_dict())
+        new_project = PlotinatorProject(paths=new_paths, metadata=metadata_copy, config=config_copy)
+
+        self._materialise_project_clone(current, new_project)
+        new_project.save()
+        self._copy_directory(current.paths.plots_dir, new_project.paths.plots_dir)
+        self._copy_directory(current.paths.exports_dir, new_project.paths.exports_dir)
+
+        self._set_project(new_project)
+        self._notify_filesystem()
+        return new_project
+
+    def current_project(self) -> PlotinatorProject:
+        """Return the active project instance."""
+
+        project = self._project
+        if project is None:
+            raise RuntimeError("No project is currently loaded")
+        return project
+
+    # Convenience -------------------------------------------------------
+
+    @property
+    def dirty(self) -> bool:
+        """Return whether the current project has unsaved changes."""
+
+        project = self._project
+        if project is None:
+            return False
+        snapshot = self._serialise_state(project)
+        self._dirty = snapshot != self._clean_snapshot
+        return self._dirty
+
+    def data_path(self, *parts: Path | str) -> Path:
+        """Resolve a path within the project's data directory."""
+
+        return self._resolve_project_path(self.current_project().paths.data_dir, parts)
+
+    def exports_path(self, *parts: Path | str) -> Path:
+        """Resolve a path within the project's exports directory."""
+
+        return self._resolve_project_path(self.current_project().paths.exports_dir, parts)
+
+    def preview_path(self, *parts: Path | str) -> Path:
+        """Resolve a path used for preview artefacts (plots directory)."""
+
+        return self._resolve_project_path(self.current_project().paths.plots_dir, parts)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+
+    def _set_project(self, project: PlotinatorProject) -> None:
+        self._project = project
+        self._clean_snapshot = self._serialise_state(project)
+        self._dirty = False
+
+    def _update_snapshot(self) -> None:
+        project = self._project
+        if project is None:
+            self._clean_snapshot = None
+            self._dirty = False
+            return
+        self._clean_snapshot = self._serialise_state(project)
+        self._dirty = False
+
+    def _load_project(self, location: Path) -> PlotinatorProject:
+        if location.is_dir():
+            candidate = location / "project.json"
+            if candidate.is_file():
+                return PlotinatorProject.load(location)
+            migrated = synthesise_temporary_project(location)
+            if migrated is not None:
+                return migrated
+        elif location.is_file():
+            parent = location.parent
+            marker = parent / "project.json"
+            if marker.is_file():
+                return PlotinatorProject.load(parent)
+            migrated = synthesise_temporary_project(location)
+            if migrated is not None:
+                return migrated
+        raise FileNotFoundError(f"Unable to locate a project at {location}")
+
+    def _materialise_project_clone(
+        self,
+        source: PlotinatorProject,
+        target: PlotinatorProject,
+    ) -> None:
+        root = target.paths.root
+        if root.exists() and any(root.iterdir()):
+            raise FileExistsError(f"Target project directory already exists: {root}")
+        root.mkdir(parents=True, exist_ok=True)
+        self._rebase_datasets(source, target)
+
+    def _rebase_datasets(self, source: PlotinatorProject, target: PlotinatorProject) -> None:
+        source_data_root = source.paths.data_dir
+        destination_root = target.paths.data_dir
+        copied: set[Path] = set()
+
+        for fit in target.config.fits:
+            for dataset in fit.datasets:
+                original_path = dataset.data_source.path
+                relative_path = self._determine_relative_dataset_path(
+                    dataset.data_source.original_path,
+                    original_path,
+                    source_data_root,
+                )
+                destination = destination_root / relative_path
+                destination.parent.mkdir(parents=True, exist_ok=True)
+
+                source_resolved = original_path.resolve()
+                destination_resolved = destination.resolve()
+                if destination_resolved not in copied:
+                    if source_resolved != destination_resolved:
+                        shutil.copy2(source_resolved, destination)
+                    else:
+                        destination.touch(exist_ok=True)
+                    copied.add(destination_resolved)
+
+                dataset.data_source.path = destination_resolved
+                dataset.data_source.original_path = relative_path.as_posix()
+
+    @staticmethod
+    def _determine_relative_dataset_path(
+        original: str | None,
+        current_path: Path,
+        data_root: Path,
+    ) -> Path:
+        if original:
+            original_path = Path(original)
+            if not original_path.is_absolute():
+                return original_path
+        try:
+            return current_path.resolve().relative_to(data_root.resolve())
+        except ValueError:
+            return Path(current_path.name)
+
+    @staticmethod
+    def _copy_directory(source: Path, destination: Path) -> None:
+        if not source.exists():
+            return
+        destination.mkdir(parents=True, exist_ok=True)
+        for item in source.iterdir():
+            target_path = destination / item.name
+            if item.is_dir():
+                ProjectManager._copy_directory(item, target_path)
+            else:
+                shutil.copy2(item, target_path)
+
+    def _serialise_state(self, project: PlotinatorProject) -> str:
+        payload = {
+            "metadata": project.metadata.to_dict(),
+            "config": project.to_config().to_dict(),
+        }
+        return json.dumps(payload, sort_keys=True)
+
+    def _notify_filesystem(self) -> None:
+        project = self._project
+        if project is None:
+            return
+        for callback in self._filesystem_callbacks:
+            callback(project.paths)
+
+    @staticmethod
+    def _resolve_project_path(base: Path, parts: Sequence[Path | str]) -> Path:
+        return base.joinpath(*parts)
+
+
+__all__ = ["ProjectManager", "FilesystemCallback"]
+

--- a/tests/test_project_manager.py
+++ b/tests/test_project_manager.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from config.schema import PlotinatorConfig
+from plotinator.project import ProjectManager
+
+
+def _write_legacy_config(root: Path) -> None:
+    data_path = root / "data.csv"
+    data_path.write_text("x,y\n1,2\n", encoding="utf-8")
+    config_payload = {
+        "fits": [
+            {
+                "title": "Example",
+                "formula": "a*x",
+                "residuals": True,
+                "datasets": [
+                    {
+                        "label": "Primary",
+                        "data_source": {
+                            "path": "data.csv",
+                            "columns": {"x": 1, "y": 2},
+                        },
+                    }
+                ],
+            }
+        ],
+        "settings": {},
+    }
+    (root / "config.json").write_text(json.dumps(config_payload), encoding="utf-8")
+
+
+def test_new_project_creates_directory_layout(tmp_path: Path) -> None:
+    events: list[Path] = []
+    manager = ProjectManager(filesystem_callbacks=[lambda paths: events.append(paths.root)])
+
+    project_root = tmp_path / "example.p10k"
+    project = manager.new_project(project_root)
+
+    assert project.paths.root == project_root
+    assert project.paths.metadata.is_file()
+    assert project.paths.fits.is_file()
+    assert project.paths.settings.is_file()
+    assert project.paths.data_dir.is_dir()
+    assert project.paths.plots_dir.is_dir()
+    assert project.paths.exports_dir.is_dir()
+    assert events[-1] == project_root
+    assert manager.dirty is False
+
+
+def test_dirty_tracking_reacts_to_metadata_and_settings(tmp_path: Path) -> None:
+    manager = ProjectManager()
+    project = manager.new_project(tmp_path / "dirty.p10k")
+
+    assert manager.dirty is False
+    project.metadata.label = "Updated"
+    assert manager.dirty is True
+
+    manager.save_project()
+    assert manager.dirty is False
+
+    project.config.settings.max_workers = 4
+    assert manager.dirty is True
+
+
+def test_save_project_as_clones_structure(tmp_path: Path) -> None:
+    manager = ProjectManager()
+    project = manager.new_project(tmp_path / "source.p10k")
+    data_file = manager.data_path("sample.csv")
+    data_file.write_text("x,y\n1,2\n", encoding="utf-8")
+
+    config_payload = {
+        "fits": [
+            {
+                "title": "Clone",
+                "formula": "a*x",
+                "residuals": True,
+                "datasets": [
+                    {
+                        "label": "Primary",
+                        "data_source": {
+                            "path": "sample.csv",
+                            "columns": {"x": 1, "y": 2},
+                        },
+                    }
+                ],
+            }
+        ],
+        "settings": {},
+    }
+
+    config = PlotinatorConfig.from_mapping(config_payload, base_path=project.paths.data_dir)
+    project.update_from_config(config)
+    manager.save_project()
+
+    target_root = tmp_path / "clone.p10k"
+    clone = manager.save_project_as(target_root)
+
+    clone_data_file = clone.paths.data_dir / "sample.csv"
+    assert clone.paths.root == target_root
+    assert clone_data_file.read_text(encoding="utf-8") == "x,y\n1,2\n"
+    dataset = clone.config.fits[0].datasets[0]
+    assert dataset.data_source.path == clone_data_file.resolve()
+    assert dataset.data_source.original_path == "sample.csv"
+
+
+def test_open_project_migrates_legacy_workspace(tmp_path: Path) -> None:
+    legacy_root = tmp_path / "legacy"
+    legacy_root.mkdir()
+    _write_legacy_config(legacy_root)
+
+    manager = ProjectManager()
+    project = manager.open_project(legacy_root)
+
+    assert project.metadata.label == "legacy"
+    assert project.paths.metadata.is_file()
+    assert manager.dirty is False
+


### PR DESCRIPTION
## Summary
- add a project manager that handles project lifecycle operations, dirty tracking, and filesystem notifications
- support project cloning and migration-aware loading with convenience path helpers
- cover the new manager behaviour with targeted unit tests

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691843d80fd08328856b5049a7579d78)