### PR TITLE
Add project data import helper and dataset normalization

### DIFF
--- a/plotinator/project/__init__.py
+++ b/plotinator/project/__init__.py
@@ -1,5 +1,6 @@
 """Project model helpers for Plotinator workspaces."""
 
+from .data import DataFileExistsError, DataImportError, import_data_file
 from .migration import (
     LEGACY_CONFIG_FILENAME,
     TEMP_PROJECT_FOLDER,
@@ -16,6 +17,9 @@ __all__ = [
     "ProjectPaths",
     "ProjectManager",
     "FilesystemCallback",
+    "import_data_file",
+    "DataFileExistsError",
+    "DataImportError",
     "LEGACY_CONFIG_FILENAME",
     "TEMP_PROJECT_FOLDER",
     "find_legacy_config",

--- a/plotinator/project/data.py
+++ b/plotinator/project/data.py
@@ -1,0 +1,106 @@
+"""Utilities for managing dataset files within Plotinator projects."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+from .models import PlotinatorProject
+
+
+class DataImportError(RuntimeError):
+    """Base exception for project data import failures."""
+
+
+class DataFileExistsError(DataImportError):
+    """Raised when attempting to import a file that already exists."""
+
+    def __init__(self, destination: Path) -> None:
+        super().__init__(f"Data file already exists: {destination.name}")
+        self.destination = destination
+
+
+def import_data_file(
+    project: PlotinatorProject,
+    source_path: Path,
+    *,
+    overwrite: bool = False,
+) -> Path:
+    """Import ``source_path`` into ``project``'s ``data`` directory.
+
+    Parameters
+    ----------
+    project:
+        The project receiving the dataset.
+    source_path:
+        The path to the source file to import.
+    overwrite:
+        When ``True`` an existing file with the same name will be replaced.
+
+    Returns
+    -------
+    Path
+        The resolved destination path inside the project's ``data`` directory.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``source_path`` does not exist.
+    IsADirectoryError
+        If ``source_path`` is a directory.
+    DataFileExistsError
+        When the destination already exists and ``overwrite`` is ``False``.
+    """
+
+    source = Path(source_path)
+    try:
+        source_resolved = source.resolve(strict=True)
+    except FileNotFoundError:  # pragma: no cover - bubbled to caller
+        raise FileNotFoundError(f"Source data file not found: {source}") from None
+
+    if not source_resolved.is_file():
+        raise IsADirectoryError(f"Source data file must be a file: {source}")
+
+    data_dir = project.paths.data_dir
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        data_root = data_dir.resolve()
+    except FileNotFoundError:
+        data_root = data_dir
+
+    try:
+        source_inside_project = source_resolved.is_relative_to(data_root)
+    except AttributeError:  # pragma: no cover - Python < 3.9 compatibility
+        source_inside_project = str(source_resolved).startswith(str(data_root))
+
+    destination = data_dir / source_resolved.name
+    try:
+        destination_resolved = destination.resolve(strict=True)
+    except FileNotFoundError:
+        destination_resolved = destination
+
+    if destination.exists():
+        try:
+            same_file = os.path.samefile(source_resolved, destination_resolved)
+        except OSError:
+            same_file = destination_resolved == source_resolved
+        if same_file and source_inside_project:
+            return destination_resolved
+        if not overwrite:
+            raise DataFileExistsError(destination)
+        if destination.is_dir():
+            raise IsADirectoryError(f"Destination is a directory: {destination}")
+        destination.unlink()
+
+    try:
+        os.link(source_resolved, destination)
+    except OSError:
+        shutil.copy2(source_resolved, destination)
+
+    return destination.resolve()
+
+
+__all__ = ["import_data_file", "DataFileExistsError", "DataImportError"]
+

--- a/plotinator/project/manager.py
+++ b/plotinator/project/manager.py
@@ -7,6 +7,7 @@ import shutil
 from pathlib import Path
 from typing import Callable, Iterable, Sequence
 
+from .data import import_data_file as _import_data_file
 from .migration import synthesise_temporary_project
 from .models import PlotinatorProject, ProjectMetadata, ProjectPaths
 
@@ -28,6 +29,7 @@ class ProjectManager:
         )
         self._clean_snapshot: str | None = None
         self._dirty: bool = False
+        self._available_data_files: list[Path] = []
 
     # ------------------------------------------------------------------
     # Public API
@@ -71,6 +73,7 @@ class ProjectManager:
         """Persist the current project state to disk."""
 
         project = self.current_project()
+        self._normalise_project_datasets(project)
         project.save()
         self._update_snapshot()
         self._notify_filesystem()
@@ -121,6 +124,29 @@ class ProjectManager:
 
         return self._resolve_project_path(self.current_project().paths.data_dir, parts)
 
+    @property
+    def available_data_files(self) -> tuple[Path, ...]:
+        """Return cached data files discovered within the project."""
+
+        return tuple(self._available_data_files)
+
+    def refresh_available_data_files(self) -> tuple[Path, ...]:
+        """Rescan the project's data directory and update the cache."""
+
+        project = self.current_project()
+        self._refresh_available_data_files(project)
+        return tuple(self._available_data_files)
+
+    def import_data_file(
+        self, source_path: Path | str, *, overwrite: bool = False
+    ) -> Path:
+        """Copy or link a data file into the project's ``data`` directory."""
+
+        project = self.current_project()
+        destination = _import_data_file(project, Path(source_path), overwrite=overwrite)
+        self._refresh_available_data_files(project)
+        return destination
+
     def exports_path(self, *parts: Path | str) -> Path:
         """Resolve a path within the project's exports directory."""
 
@@ -136,6 +162,8 @@ class ProjectManager:
 
     def _set_project(self, project: PlotinatorProject) -> None:
         self._project = project
+        self._normalise_project_datasets(project)
+        self._refresh_available_data_files(project)
         self._clean_snapshot = self._serialise_state(project)
         self._dirty = False
 
@@ -147,6 +175,7 @@ class ProjectManager:
             return
         self._clean_snapshot = self._serialise_state(project)
         self._dirty = False
+        self._refresh_available_data_files(project)
 
     def _load_project(self, location: Path) -> PlotinatorProject:
         if location.is_dir():
@@ -231,6 +260,66 @@ class ProjectManager:
                 ProjectManager._copy_directory(item, target_path)
             else:
                 shutil.copy2(item, target_path)
+
+    def _refresh_available_data_files(self, project: PlotinatorProject) -> None:
+        try:
+            data_root = project.paths.data_dir.resolve()
+        except FileNotFoundError:
+            data_root = project.paths.data_dir
+        if not data_root.exists():
+            self._available_data_files = []
+            return
+
+        files: list[Path] = []
+        try:
+            for candidate in data_root.rglob("*"):
+                try:
+                    if not candidate.is_file():
+                        continue
+                except OSError:
+                    continue
+                try:
+                    files.append(candidate.resolve())
+                except FileNotFoundError:
+                    continue
+        except OSError:
+            self._available_data_files = []
+            return
+
+        files.sort()
+        self._available_data_files = files
+
+    def _normalise_project_datasets(self, project: PlotinatorProject) -> None:
+        try:
+            data_root = project.paths.data_dir.resolve()
+        except FileNotFoundError:
+            data_root = project.paths.data_dir
+        try:
+            project_root = project.paths.root.resolve()
+        except FileNotFoundError:
+            project_root = project.paths.root
+
+        for fit in project.config.fits:
+            for dataset in fit.datasets:
+                source = dataset.data_source
+                candidate_path = source.path
+                if not candidate_path.is_absolute():
+                    candidate_path = project_root / candidate_path
+                try:
+                    resolved = candidate_path.resolve()
+                except FileNotFoundError:
+                    resolved = candidate_path
+                try:
+                    relative = resolved.relative_to(data_root)
+                except ValueError:
+                    continue
+
+                destination = data_root / relative
+                try:
+                    source.path = destination.resolve()
+                except FileNotFoundError:
+                    source.path = destination
+                source.original_path = relative.as_posix()
 
     def _serialise_state(self, project: PlotinatorProject) -> str:
         payload = {

--- a/tests/test_project_data.py
+++ b/tests/test_project_data.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+import pytest
+
+from plotinator.project import PlotinatorProject, ProjectPaths
+from plotinator.project.data import DataFileExistsError, import_data_file
+
+
+def _make_project(tmp_path: Path) -> PlotinatorProject:
+    root = tmp_path / "example.p10k"
+    paths = ProjectPaths.from_root(root)
+    project = PlotinatorProject(paths=paths)
+    project.save()
+    return project
+
+
+def test_import_data_file_copies_into_data_dir(tmp_path: Path) -> None:
+    project = _make_project(tmp_path)
+    source = tmp_path / "sample.dat"
+    source.write_text("1 2\n", encoding="utf-8")
+
+    destination = import_data_file(project, source)
+
+    assert destination.parent == project.paths.data_dir
+    assert destination.name == source.name
+    assert destination.read_text(encoding="utf-8") == "1 2\n"
+
+
+def test_import_data_file_detects_duplicates(tmp_path: Path) -> None:
+    project = _make_project(tmp_path)
+    source = tmp_path / "duplicate.dat"
+    source.write_text("first\n", encoding="utf-8")
+
+    import_data_file(project, source)
+
+    with pytest.raises(DataFileExistsError):
+        import_data_file(project, source)
+
+
+def test_import_data_file_can_overwrite(tmp_path: Path) -> None:
+    project = _make_project(tmp_path)
+    source = tmp_path / "overwrite.dat"
+    source.write_text("initial\n", encoding="utf-8")
+
+    import_data_file(project, source)
+    source.write_text("updated\n", encoding="utf-8")
+
+    destination = import_data_file(project, source, overwrite=True)
+
+    assert destination.read_text(encoding="utf-8") == "updated\n"
+

--- a/tests/test_project_manager.py
+++ b/tests/test_project_manager.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from config.schema import PlotinatorConfig
-from plotinator.project import ProjectManager
+from plotinator.project import DataFileExistsError, ProjectManager
 
 
 def _write_legacy_config(root: Path) -> None:
@@ -117,4 +119,69 @@ def test_open_project_migrates_legacy_workspace(tmp_path: Path) -> None:
     assert project.metadata.label == "legacy"
     assert project.paths.metadata.is_file()
     assert manager.dirty is False
+
+
+def test_import_data_file_updates_available_cache(tmp_path: Path) -> None:
+    manager = ProjectManager()
+    manager.new_project(tmp_path / "cache.p10k")
+
+    assert manager.available_data_files == ()
+
+    source = tmp_path / "data.dat"
+    source.write_text("1 2\n", encoding="utf-8")
+
+    destination = manager.import_data_file(source)
+
+    assert destination in manager.available_data_files
+
+    with pytest.raises(DataFileExistsError):
+        manager.import_data_file(source)
+
+    source.write_text("2 3\n", encoding="utf-8")
+    updated = manager.import_data_file(source, overwrite=True)
+
+    assert updated.read_text(encoding="utf-8") == "2 3\n"
+    assert updated in manager.available_data_files
+
+
+def test_save_project_normalises_absolute_dataset_paths(tmp_path: Path) -> None:
+    manager = ProjectManager()
+    project = manager.new_project(tmp_path / "normalise.p10k")
+
+    source = tmp_path / "source.dat"
+    source.write_text("1 2\n", encoding="utf-8")
+
+    destination = manager.import_data_file(source)
+
+    config_payload = {
+        "fits": [
+            {
+                "title": "Absolute",
+                "formula": "a*x",
+                "residuals": False,
+                "datasets": [
+                    {
+                        "label": "Primary",
+                        "data_source": {
+                            "path": destination.as_posix(),
+                            "columns": {"x": 1, "y": 2},
+                        },
+                    }
+                ],
+            }
+        ],
+        "settings": {},
+    }
+
+    config = PlotinatorConfig.from_mapping(config_payload, base_path=project.paths.data_dir)
+    project.update_from_config(config)
+
+    manager.save_project()
+
+    dataset = project.config.fits[0].datasets[0]
+    assert dataset.data_source.original_path == destination.name
+    assert dataset.data_source.path == destination.resolve()
+
+    saved_fits = json.loads(project.paths.fits.read_text(encoding="utf-8"))
+    assert saved_fits[0]["datasets"][0]["data_source"]["path"] == destination.name
 


### PR DESCRIPTION
## Summary
- add a data import helper that places files under a project's data directory and enforces duplicate checks
- extend the project manager with dataset path normalization and an available data file cache that integrates with the import helper
- cover the new utilities and manager workflow with unit tests

## Testing
- pytest tests/test_project_data.py tests/test_project_manager.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c396396c83288cbca062c17dd10c)