### PR TITLE
Add validation checks for Plotinator projects

### DIFF
--- a/plotinator/project/__init__.py
+++ b/plotinator/project/__init__.py
@@ -9,13 +9,23 @@ from .migration import (
 )
 from .manager import FilesystemCallback, ProjectManager
 from .models import PlotinatorProject, ProjectMetadata, ProjectPaths
+from .validation import (
+    ProjectValidationError,
+    ValidationIssue,
+    ValidationResult,
+    validate_project,
+)
 
 __all__ = [
     "PlotinatorProject",
     "ProjectMetadata",
     "ProjectPaths",
     "ProjectManager",
+    "validate_project",
     "FilesystemCallback",
+    "ProjectValidationError",
+    "ValidationResult",
+    "ValidationIssue",
     "LEGACY_CONFIG_FILENAME",
     "TEMP_PROJECT_FOLDER",
     "find_legacy_config",

--- a/plotinator/project/manager.py
+++ b/plotinator/project/manager.py
@@ -7,8 +7,11 @@ import shutil
 from pathlib import Path
 from typing import Callable, Iterable, Sequence
 
+from config.schema import ConfigError
+
 from .migration import synthesise_temporary_project
 from .models import PlotinatorProject, ProjectMetadata, ProjectPaths
+from .validation import ProjectValidationError, ValidationResult, validate_project
 
 
 FilesystemCallback = Callable[[ProjectPaths], None]
@@ -63,6 +66,7 @@ class ProjectManager:
 
         path = Path(location)
         project = self._load_project(path)
+        self._enforce_valid(project, check_structure=True)
         self._set_project(project)
         self._notify_filesystem()
         return project
@@ -71,7 +75,9 @@ class ProjectManager:
         """Persist the current project state to disk."""
 
         project = self.current_project()
+        self._enforce_valid(project, check_structure=False)
         project.save()
+        self._enforce_valid(project, check_structure=True)
         self._update_snapshot()
         self._notify_filesystem()
         return project
@@ -87,7 +93,9 @@ class ProjectManager:
         new_project = PlotinatorProject(paths=new_paths, metadata=metadata_copy, config=config_copy)
 
         self._materialise_project_clone(current, new_project)
+        self._enforce_valid(new_project, check_structure=False)
         new_project.save()
+        self._enforce_valid(new_project, check_structure=True)
         self._copy_directory(current.paths.plots_dir, new_project.paths.plots_dir)
         self._copy_directory(current.paths.exports_dir, new_project.paths.exports_dir)
 
@@ -152,19 +160,45 @@ class ProjectManager:
         if location.is_dir():
             candidate = location / "project.json"
             if candidate.is_file():
-                return PlotinatorProject.load(location)
+                return self._safe_load(location)
             migrated = synthesise_temporary_project(location)
             if migrated is not None:
+                self._enforce_valid(migrated, check_structure=True)
                 return migrated
         elif location.is_file():
             parent = location.parent
             marker = parent / "project.json"
             if marker.is_file():
-                return PlotinatorProject.load(parent)
+                return self._safe_load(parent)
             migrated = synthesise_temporary_project(location)
             if migrated is not None:
+                self._enforce_valid(migrated, check_structure=True)
                 return migrated
         raise FileNotFoundError(f"Unable to locate a project at {location}")
+
+    def _safe_load(self, root: Path) -> PlotinatorProject:
+        try:
+            return PlotinatorProject.load(root)
+        except (ConfigError, ValueError) as exc:
+            paths = ProjectPaths.from_root(root)
+            result = ValidationResult(paths=paths)
+            message = str(exc)
+            code = "invalid-config" if isinstance(exc, ConfigError) else "invalid-json"
+            if isinstance(exc, ConfigError) and "Data file not found for" in message:
+                code = "dangling-dataset"
+            target_path = paths.fits
+            for candidate in (paths.metadata, paths.fits, paths.settings):
+                if candidate.name in message:
+                    target_path = candidate
+                    break
+            result.add_issue(
+                code=code,
+                message=message,
+                path=target_path,
+                subject="config",
+                hint="Review the configuration files and correct the reported problem.",
+            )
+            raise ProjectValidationError(result) from exc
 
     def _materialise_project_clone(
         self,
@@ -245,6 +279,11 @@ class ProjectManager:
             return
         for callback in self._filesystem_callbacks:
             callback(project.paths)
+
+    def _enforce_valid(self, project: PlotinatorProject, *, check_structure: bool) -> None:
+        result = validate_project(project, check_structure=check_structure)
+        if not result.ok:
+            raise ProjectValidationError(result)
 
     @staticmethod
     def _resolve_project_path(base: Path, parts: Sequence[Path | str]) -> Path:

--- a/plotinator/project/validation.py
+++ b/plotinator/project/validation.py
@@ -1,0 +1,156 @@
+"""Validation helpers for Plotinator project layouts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .models import PlotinatorProject, ProjectPaths
+
+
+@dataclass(slots=True)
+class ValidationIssue:
+    """Describe a specific validation problem detected within a project."""
+
+    code: str
+    message: str
+    path: Path | None = None
+    subject: str | None = None
+    hint: str | None = None
+    details: dict[str, Any] | None = None
+
+
+@dataclass(slots=True)
+class ValidationResult:
+    """Aggregate outcome produced by the project validation routine."""
+
+    paths: ProjectPaths
+    issues: list[ValidationIssue] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        """Return ``True`` when no validation issues were detected."""
+
+        return not self.issues
+
+    def add_issue(
+        self,
+        *,
+        code: str,
+        message: str,
+        path: Path | None = None,
+        subject: str | None = None,
+        hint: str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        """Append a new issue to the result set."""
+
+        self.issues.append(
+            ValidationIssue(
+                code=code,
+                message=message,
+                path=path,
+                subject=subject,
+                hint=hint,
+                details=details,
+            )
+        )
+
+
+class ProjectValidationError(RuntimeError):
+    """Raised when validation fails for a Plotinator project."""
+
+    def __init__(self, result: ValidationResult):
+        self.result = result
+        summary = result.issues[0].message if result.issues else "Project validation failed"
+        super().__init__(summary)
+
+
+def validate_project(
+    project: PlotinatorProject,
+    *,
+    check_structure: bool = True,
+) -> ValidationResult:
+    """Validate a project instance and return a rich diagnostic report."""
+
+    result = ValidationResult(paths=project.paths)
+
+    if check_structure:
+        _check_structure(project.paths, result)
+
+    _check_datasets(project, result)
+
+    return result
+
+
+def _check_structure(paths: ProjectPaths, result: ValidationResult) -> None:
+    """Ensure the project folder contains the expected layout."""
+
+    structure_expectations = {
+        "root": (paths.root, Path.is_dir, "Project root folder is missing"),
+        "metadata": (paths.metadata, Path.is_file, "Missing project metadata file"),
+        "fits": (paths.fits, Path.is_file, "Missing fits configuration file"),
+        "settings": (paths.settings, Path.is_file, "Missing project settings file"),
+        "data": (paths.data_dir, Path.is_dir, "Missing data directory"),
+        "plots": (paths.plots_dir, Path.is_dir, "Missing plots directory"),
+        "exports": (paths.exports_dir, Path.is_dir, "Missing exports directory"),
+    }
+
+    for subject, (path, predicate, message) in structure_expectations.items():
+        try:
+            valid = predicate(path)
+        except OSError:
+            valid = False
+        if not valid:
+            result.add_issue(
+                code="missing-path",
+                message=f"{message}: {path}",
+                path=path,
+                subject=subject,
+                hint="Recreate the missing file or directory and retry.",
+            )
+
+
+def _check_datasets(project: PlotinatorProject, result: ValidationResult) -> None:
+    """Verify that all datasets referenced by the project remain available."""
+
+    for fit_index, fit in enumerate(project.config.fits, start=1):
+        for dataset_index, dataset in enumerate(fit.datasets, start=1):
+            data_path = dataset.data_source.path
+            exists = data_path.exists()
+            is_file = data_path.is_file() if exists else False
+            if exists and is_file:
+                continue
+
+            subject = f"fits[{fit_index - 1}].datasets[{dataset_index - 1}]"
+            message = (
+                f"Dataset '{dataset.label}' in fit '{fit.title}' references "
+                f"missing data file: {dataset.data_source.original_path or data_path}"
+            )
+            hint = "Restore the referenced dataset or update the dataset path."
+            details: dict[str, Any] = {
+                "fit": fit.title,
+                "dataset": dataset.label,
+                "dataset_index": dataset_index - 1,
+                "fit_index": fit_index - 1,
+                "requested_path": str(dataset.data_source.original_path or data_path),
+                "resolved_path": str(data_path),
+            }
+            result.add_issue(
+                code="dangling-dataset",
+                message=message,
+                path=data_path,
+                subject=subject,
+                hint=hint,
+                details=details,
+            )
+
+
+__all__ = [
+    "ValidationIssue",
+    "ValidationResult",
+    "ProjectValidationError",
+    "validate_project",
+]
+

--- a/tests/test_project_manager.py
+++ b/tests/test_project_manager.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from config.schema import PlotinatorConfig
-from plotinator.project import ProjectManager
+from plotinator.project import ProjectManager, ProjectValidationError
 
 
 def _write_legacy_config(root: Path) -> None:
@@ -117,4 +119,79 @@ def test_open_project_migrates_legacy_workspace(tmp_path: Path) -> None:
     assert project.metadata.label == "legacy"
     assert project.paths.metadata.is_file()
     assert manager.dirty is False
+
+
+def test_open_project_rejects_incomplete_structure(tmp_path: Path) -> None:
+    project_root = tmp_path / "broken.p10k"
+    project_root.mkdir()
+    (project_root / "project.json").write_text("{}", encoding="utf-8")
+    (project_root / "fits.json").write_text("[]", encoding="utf-8")
+    for folder in ("data", "plots", "exports"):
+        (project_root / folder).mkdir()
+
+    manager = ProjectManager()
+
+    with pytest.raises(ProjectValidationError) as excinfo:
+        manager.open_project(project_root)
+
+    issues = excinfo.value.result.issues
+    assert any(issue.subject == "settings" for issue in issues)
+
+
+def test_open_project_reports_invalid_json(tmp_path: Path) -> None:
+    project_root = tmp_path / "invalid-json.p10k"
+    project_root.mkdir()
+    (project_root / "project.json").write_text("{}", encoding="utf-8")
+    (project_root / "settings.json").write_text("{}", encoding="utf-8")
+    (project_root / "fits.json").write_text("{", encoding="utf-8")
+    for folder in ("data", "plots", "exports"):
+        (project_root / folder).mkdir()
+
+    manager = ProjectManager()
+
+    with pytest.raises(ProjectValidationError) as excinfo:
+        manager.open_project(project_root)
+
+    issue = excinfo.value.result.issues[0]
+    assert issue.code == "invalid-json"
+    assert issue.path == project_root / "fits.json"
+
+
+def test_save_project_rejects_missing_dataset(tmp_path: Path) -> None:
+    manager = ProjectManager()
+    project = manager.new_project(tmp_path / "dangling.p10k")
+
+    data_file = manager.data_path("input.csv")
+    data_file.write_text("x,y\n1,2\n", encoding="utf-8")
+
+    config_payload = {
+        "fits": [
+            {
+                "title": "Dangling",
+                "formula": "a*x",
+                "datasets": [
+                    {
+                        "label": "Primary",
+                        "data_source": {
+                            "path": "input.csv",
+                            "columns": {"x": 1, "y": 2},
+                        },
+                    }
+                ],
+            }
+        ],
+        "settings": {},
+    }
+
+    config = PlotinatorConfig.from_mapping(config_payload, base_path=project.paths.data_dir)
+    project.update_from_config(config)
+    manager.save_project()
+
+    data_file.unlink()
+
+    with pytest.raises(ProjectValidationError) as excinfo:
+        manager.save_project()
+
+    issues = excinfo.value.result.issues
+    assert issues[0].code == "dangling-dataset"
 


### PR DESCRIPTION
## Summary
- add a dedicated validation module that reports structural issues and missing datasets with actionable context
- enforce validation in ProjectManager lifecycle operations and expose the error types through the public API
- cover invalid layouts and broken datasets with new project manager tests

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c669add8832892a030a9638792f6)