### PR TITLE
Support project-managed output locations

### DIFF
--- a/engine/runner.py
+++ b/engine/runner.py
@@ -8,8 +8,12 @@ import shutil
 import subprocess
 import tempfile
 import traceback
+import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from plotinator.project import ProjectPaths
 
 from config import ConfigError, JobSettings, load_config_file
 from reports.markdown_builder import write_markdown_report
@@ -131,7 +135,19 @@ def _normalize_path(path: str | None) -> str | None:
     return os.path.abspath(path).replace("\\", "/")
 
 
-def _prepare_preview_payload(result: dict[str, Any]) -> dict[str, Any]:
+def _allocate_preview_dir(base_dir: str | os.PathLike[str] | None) -> str:
+    if base_dir is None:
+        return tempfile.mkdtemp(prefix="plotinator_preview_")
+
+    directory = os.path.join(os.fspath(base_dir), f"preview_{uuid.uuid4().hex}")
+    os.makedirs(directory, exist_ok=True)
+    return directory
+
+
+def _prepare_preview_payload(
+    result: dict[str, Any],
+    preview_temp_root: str | os.PathLike[str] | None = None,
+) -> dict[str, Any]:
     output_plot = result.get("output_plot")
     residuals_plot = result.get("residuals_plot")
     preview_plot = output_plot
@@ -148,7 +164,7 @@ def _prepare_preview_payload(result: dict[str, Any]) -> dict[str, Any]:
         existing_files.append(("residuals", residuals_plot))
 
     if existing_files:
-        cleanup_dir = tempfile.mkdtemp(prefix="plotinator_preview_")
+        cleanup_dir = _allocate_preview_dir(preview_temp_root)
         try:
             for kind, source in existing_files:
                 base_name = os.path.basename(source) or (
@@ -223,6 +239,8 @@ def process_plot(
     plot_cfg: dict,
     base_output: str,
     dispatcher: _EventDispatcher | None = None,
+    *,
+    preview_base_dir: str | os.PathLike[str] | None = None,
 ) -> dict:
     """Handle a single plot end-to-end: create folder, run fit, residuals, and metrics."""
 
@@ -338,7 +356,7 @@ def process_plot(
     event_kwargs: dict[str, Any] = {"title": plot_cfg.get("title", "Untitled")}
     if dispatcher and dispatcher.has_callback():
         event_kwargs["result"] = copy.deepcopy(result)
-        event_kwargs["preview"] = _prepare_preview_payload(result)
+        event_kwargs["preview"] = _prepare_preview_payload(result, preview_base_dir)
 
     if dispatcher:
         dispatcher.emit("plot-complete", **event_kwargs)
@@ -355,6 +373,7 @@ def run_job(
     max_workers: int | None = None,
     output_dir: str | os.PathLike[str] | None = None,
     on_event: Callable[[dict[str, Any]], None] | None = None,
+    project_paths: "ProjectPaths | None" = None,
 ) -> dict[str, Any]:
     """Execute a batch fit job from an in-memory config definition."""
 
@@ -365,12 +384,25 @@ def run_job(
         ts = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
 
         job_settings = settings
-        if output_dir is not None:
-            base_output = os.fspath(output_dir)
-        elif job_settings and job_settings.output_dir is not None:
-            base_output = os.fspath(job_settings.output_dir)
+        preview_temp_root: str | None = None
+        exports_output_dir: str | None = None
+
+        if project_paths is not None:
+            plots_root = os.path.abspath(os.fspath(project_paths.plots_dir))
+            exports_root = os.path.abspath(os.fspath(project_paths.exports_dir))
+            os.makedirs(plots_root, exist_ok=True)
+            os.makedirs(exports_root, exist_ok=True)
+            base_output = os.path.join(plots_root, ts)
+            preview_temp_root = os.path.join(base_output, "__previews__")
+            exports_output_dir = os.path.join(exports_root, ts)
         else:
-            base_output = os.path.abspath(os.path.join("outputs", ts))
+            if output_dir is not None:
+                base_output = os.fspath(output_dir)
+            elif job_settings and job_settings.output_dir is not None:
+                base_output = os.fspath(job_settings.output_dir)
+            else:
+                base_output = os.path.abspath(os.path.join("outputs", ts))
+
         os.makedirs(base_output, exist_ok=True)
 
         worker_count: int
@@ -389,7 +421,15 @@ def run_job(
 
         with ThreadPoolExecutor(max_workers=worker_count) as executor:
             for plot_cfg in plots:
-                futures[executor.submit(process_plot, plot_cfg, base_output, dispatcher)] = plot_cfg
+                futures[
+                    executor.submit(
+                        process_plot,
+                        plot_cfg,
+                        base_output,
+                        dispatcher,
+                        preview_base_dir=preview_temp_root,
+                    )
+                ] = plot_cfg
 
             for future in as_completed(futures):
                 plot_cfg = futures[future]
@@ -417,8 +457,12 @@ def run_job(
         markdown_path: str | None = None
         pdf_path: str | None = None
 
+        markdown_output_dir = exports_output_dir or base_output
+
         try:
-            markdown_path = str(write_markdown_report(json_path))
+            markdown_path = str(
+                write_markdown_report(json_path, output_folder=markdown_output_dir)
+            )
             dispatcher.emit(
                 "report-markdown-ready",
                 markdown_path=markdown_path,
@@ -475,6 +519,7 @@ def run_batch(
     max_workers: int | None = None,
     output_dir: str | os.PathLike[str] | None = None,
     on_event: Callable[[dict[str, Any]], None] | None = None,
+    project_paths: "ProjectPaths | None" = None,
 ) -> dict[str, Any]:
     try:
         job = load_config_file(config_path)
@@ -494,4 +539,5 @@ def run_batch(
         max_workers=max_workers,
         output_dir=output_dir,
         on_event=on_event,
+        project_paths=project_paths,
     )

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -8,6 +8,7 @@ import pytest
 
 from config import JobSettings
 from engine import runner
+from plotinator.project import ProjectPaths
 
 
 def _install_pipeline_stubs(
@@ -51,12 +52,19 @@ def _install_pipeline_stubs(
     def fake_compute_metrics(*_: object) -> dict[str, float]:
         return {"r2": 0.99, "rmse": 0.5}
 
-    def fake_write_markdown(results_path: str) -> Path:
-        md_path = output_dir / "report.md"
+    def fake_write_markdown(
+        results_path: str,
+        *,
+        output_folder: str | Path | None = None,
+        filename: str = "report.md",
+    ) -> Path:
+        target_dir = Path(output_folder) if output_folder else output_dir
+        target_dir.mkdir(parents=True, exist_ok=True)
+        md_path = target_dir / filename
         md_path.write_text(f"results: {results_path}", encoding="utf-8")
         return md_path
 
-    def fake_export_pdf(markdown_path: str) -> Path:
+    def fake_export_pdf(markdown_path: str, *_, **__) -> Path:
         if export_pdf_exception is not None:
             raise export_pdf_exception
         pdf_path = Path(markdown_path).with_suffix(".pdf")
@@ -138,6 +146,53 @@ def test_run_job_produces_artifacts(
     if cleanup_dir:
         assert Path(cleanup_dir).exists()
 
+
+def test_run_job_with_project_paths(
+    minimal_config: dict,
+    sample_paths,
+    config_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Providing project paths should redirect outputs into project folders."""
+
+    events: list[dict] = []
+    project_root = tmp_path / "project"
+    project_paths = ProjectPaths.from_root(project_root)
+
+    _install_pipeline_stubs(monkeypatch, project_paths.plots_dir)
+
+    result = runner.run_job(
+        minimal_config,
+        config_path=str(config_path),
+        settings=JobSettings(max_workers=1),
+        on_event=events.append,
+        project_paths=project_paths,
+    )
+
+    output_dir = Path(result["output_dir"])
+    assert output_dir.is_dir()
+    assert output_dir.parent == project_paths.plots_dir.resolve()
+    assert Path(result["results_path"]).is_relative_to(output_dir)
+
+    assert result["markdown_path"] is not None
+    assert result["pdf_path"] is not None
+    markdown_path = Path(result["markdown_path"])
+    pdf_path = Path(result["pdf_path"])
+    expected_exports_dir = (project_paths.exports_dir / output_dir.name).resolve()
+    assert markdown_path.parent == expected_exports_dir
+    assert pdf_path.parent == expected_exports_dir
+    assert markdown_path.exists()
+    assert pdf_path.exists()
+
+    plot_events = [event for event in events if event.get("type") == "plot-complete"]
+    assert plot_events
+    for event in plot_events:
+        preview = event.get("preview") or {}
+        cleanup_dir = preview.get("cleanup_dir")
+        if cleanup_dir:
+            cleanup_path = Path(cleanup_dir)
+            assert cleanup_path.is_relative_to(output_dir)
 
 def test_run_job_handles_pdf_export_error(
     minimal_config: dict,


### PR DESCRIPTION
## Summary
- allow `run_job` and `run_batch` to accept project descriptors and adjust output directories
- store preview copies in project-managed locations and emit updated events
- extend runner tests to cover project path routing and updated stubs

## Testing
- pytest tests/test_runner.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c80aac90832881a870f7cc2d2f2c)