### PR TITLE
Handle project-relative dataset paths in engine

### DIFF
--- a/engine/config.py
+++ b/engine/config.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 from config import LayoutConfig, load_config
 from config import infer_parameters as _infer_parameters
@@ -27,9 +27,106 @@ def infer_parameters(formula: str) -> list[str]:
     return _infer_parameters(formula)
 
 
+def _coerce_path(value: Any) -> Path | None:
+    if value is None or value == "":
+        return None
+    try:
+        path = Path(str(value)).expanduser()
+    except Exception:
+        return None
+    try:
+        return path.resolve()
+    except OSError:
+        # ``resolve`` can fail on some platforms when intermediate directories are
+        # missing; fall back to the non-resolved path in that scenario.
+        return path
+
+
+def _determine_project_context(
+    cfg: Mapping[str, Any] | None, config_path: Path
+) -> tuple[Path | None, Path]:
+    base_dir = config_path.parent.resolve()
+    project_root: Path | None = None
+    data_root: Path | None = None
+
+    if isinstance(cfg, Mapping):
+        raw_project_root = cfg.get("project_root") or cfg.get("projectRoot")
+        project_section = cfg.get("project")
+
+        if raw_project_root is not None:
+            project_root = _coerce_path(raw_project_root)
+
+        if isinstance(project_section, Mapping):
+            section_root = project_section.get("root") or project_section.get("path")
+            if section_root is not None and project_root is None:
+                project_root = _coerce_path(section_root)
+
+            data_value = (
+                project_section.get("data_root")
+                or project_section.get("data")
+                or project_section.get("data_dir")
+            )
+            if data_value is not None:
+                data_path = _coerce_path(data_value)
+                if data_path is None and project_root is not None:
+                    try:
+                        candidate = project_root / str(data_value)
+                    except Exception:
+                        candidate = None
+                    else:
+                        data_path = _coerce_path(candidate)
+                if data_path is not None:
+                    data_root = data_path
+
+    if project_root is None:
+        marker = base_dir / "project.json"
+        if marker.is_file():
+            project_root = base_dir
+
+    if data_root is None and project_root is not None:
+        candidate = project_root / "data"
+        if candidate.exists():
+            data_root = candidate.resolve()
+
+    if data_root is None:
+        data_root = base_dir
+
+    return project_root, data_root
+
+
 def normalize_plots(cfg: dict, config_path: str) -> list[dict[str, Any]]:
     """Normalize the list of plot definitions for the engine."""
 
-    base_path = Path(config_path).resolve().parent
-    job = load_config(cfg, base_path=base_path)
-    return job.to_engine_payload()
+    config_file = Path(config_path).resolve()
+    cfg_mapping = cfg if isinstance(cfg, Mapping) else None
+    project_root, data_root = _determine_project_context(cfg_mapping, config_file)
+    job = load_config(cfg, base_path=data_root)
+    plots = job.to_engine_payload()
+
+    project_root_str = str(project_root) if project_root is not None else None
+    data_root_str = str(data_root)
+    config_dir_str = str(config_file.parent.resolve())
+
+    for plot in plots:
+        plot.setdefault("config_base_dir", config_dir_str)
+        if project_root_str:
+            plot.setdefault("project_root", project_root_str)
+        plot.setdefault("project_data_root", data_root_str)
+
+        datasets = plot.get("datasets") or []
+        for dataset in datasets:
+            dataset.setdefault("config_base_dir", config_dir_str)
+            if project_root_str:
+                dataset.setdefault("project_root", project_root_str)
+            dataset.setdefault("project_data_root", data_root_str)
+
+            data_source = dataset.get("data_source")
+            if isinstance(data_source, Mapping):
+                data_source = dict(data_source)
+                data_source.setdefault("config_base_dir", config_dir_str)
+                if project_root_str:
+                    data_source.setdefault("project_root", project_root_str)
+                data_source.setdefault("project_data_root", data_root_str)
+                dataset["data_source"] = data_source
+
+    return plots

--- a/engine/data_pipeline.py
+++ b/engine/data_pipeline.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import math
 import os
-from typing import Any, Sequence, Tuple
+from pathlib import Path
+from typing import Any, Mapping, Sequence, Tuple
 
 import numpy as np
 
@@ -10,6 +11,60 @@ __all__ = [
     "prepare_datafile",
     "apply_preprocessing",
 ]
+
+
+def _resolve_dataset_path(
+    path: str,
+    *,
+    plot_cfg: Mapping[str, Any],
+    data_source: Mapping[str, Any] | None = None,
+) -> str:
+    if not path:
+        return path
+
+    path_obj = Path(path)
+    if path_obj.is_absolute():
+        return str(path_obj)
+
+    data_source = data_source or {}
+    project_data_root = data_source.get("project_data_root") or plot_cfg.get("project_data_root")
+    project_root = data_source.get("project_root") or plot_cfg.get("project_root")
+    config_base_dir = data_source.get("config_base_dir") or plot_cfg.get("config_base_dir")
+
+    candidates: list[Path] = []
+
+    def _add_candidate(base: Any, relative: Path) -> None:
+        if not base:
+            return
+        try:
+            base_path = Path(str(base))
+        except Exception:
+            return
+        candidates.append(base_path / relative)
+
+    _add_candidate(project_data_root, path_obj)
+    _add_candidate(project_root, path_obj)
+    _add_candidate(config_base_dir, path_obj)
+
+    if project_root and project_data_root:
+        try:
+            data_root_name = Path(str(project_data_root)).name
+        except Exception:
+            data_root_name = None
+        parts = path_obj.parts
+        if data_root_name and parts and parts[0].lower() == data_root_name.lower():
+            trimmed = Path(*parts[1:]) if len(parts) > 1 else None
+            if trimmed and trimmed.parts:
+                _add_candidate(project_root, trimmed)
+
+    for candidate in candidates:
+        if candidate.exists():
+            return str(candidate.resolve())
+
+    if candidates:
+        return str(candidates[0])
+
+    return os.path.abspath(path)
 
 
 def _load_data_matrix(path: str) -> np.ndarray:
@@ -118,6 +173,8 @@ def apply_preprocessing(
 def prepare_datafile(plot_cfg: dict, plot_dir: str) -> dict:
     data_source = plot_cfg.get("data_source") or {}
     source_path = data_source.get("path") or plot_cfg.get("datafile")
+    if source_path:
+        source_path = _resolve_dataset_path(source_path, plot_cfg=plot_cfg, data_source=data_source)
     steps = data_source.get("preprocessing") or []
 
     if not steps:

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+from engine.data_pipeline import prepare_datafile
+
+
+def _write_dataset(path: Path) -> None:
+    path.write_text("0 1\n1 2\n", encoding="utf-8")
+
+
+def test_prepare_datafile_resolves_project_relative_paths(tmp_path: Path) -> None:
+    project_root = tmp_path / "Example.p10k"
+    data_root = project_root / "data"
+    data_root.mkdir(parents=True)
+    data_file = data_root / "sample.dat"
+    _write_dataset(data_file)
+
+    plot_cfg = {
+        "project_root": str(project_root.resolve()),
+        "project_data_root": str(data_root.resolve()),
+        "data_source": {
+            "path": "sample.dat",
+            "project_root": str(project_root.resolve()),
+            "project_data_root": str(data_root.resolve()),
+        },
+    }
+
+    result = prepare_datafile(plot_cfg, str(tmp_path))
+
+    assert Path(result["path"]).resolve() == data_file.resolve()
+    assert result["rows_before"] == 2
+    assert result["rows_after"] == 2
+
+
+def test_prepare_datafile_handles_prefixed_data_paths(tmp_path: Path) -> None:
+    project_root = tmp_path / "Example.p10k"
+    data_root = project_root / "data"
+    data_root.mkdir(parents=True)
+    data_file = data_root / "sample.dat"
+    _write_dataset(data_file)
+
+    plot_cfg = {
+        "project_root": str(project_root.resolve()),
+        "project_data_root": str(data_root.resolve()),
+        "data_source": {
+            "path": "data/sample.dat",
+            "project_root": str(project_root.resolve()),
+            "project_data_root": str(data_root.resolve()),
+        },
+    }
+
+    result = prepare_datafile(plot_cfg, str(tmp_path))
+
+    assert Path(result["path"]).resolve() == data_file.resolve()

--- a/tests/test_engine_config.py
+++ b/tests/test_engine_config.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+from engine.config import normalize_plots
+
+
+def test_normalize_plots_detects_project_context(tmp_path: Path) -> None:
+    project_root = tmp_path / "Example.p10k"
+    data_root = project_root / "data"
+    data_root.mkdir(parents=True)
+    (project_root / "project.json").write_text("{}", encoding="utf-8")
+
+    data_file = data_root / "sample.dat"
+    data_file.write_text("0 0\n1 1\n", encoding="utf-8")
+
+    cfg = {
+        "fits": [
+            {
+                "title": "Example",
+                "formula": "a*x",
+                "data_source": {
+                    "path": "sample.dat",
+                    "columns": {"x": 1, "y": 2},
+                },
+            }
+        ]
+    }
+
+    plots = normalize_plots(cfg, str(project_root / "fits.json"))
+
+    assert plots
+    plot = plots[0]
+    assert plot["project_root"] == str(project_root.resolve())
+    assert plot["project_data_root"] == str(data_root.resolve())
+    dataset = plot["datasets"][0]
+    assert dataset["datafile"] == str(data_file.resolve())
+    assert dataset["data_source"]["project_data_root"] == str(data_root.resolve())


### PR DESCRIPTION
## Summary
- detect project roots during plot normalization so engine payloads include project metadata
- resolve project-relative dataset paths in the data pipeline, including legacy `data/` prefixed inputs
- add regression tests covering project-aware normalization and path resolution

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c81f98b08328ba5528440c568271)