### PR TITLE
Add coverage for project workflows and GUI smoke flow

### DIFF
--- a/tests/smoke/test_gui_project_flow.py
+++ b/tests/smoke/test_gui_project_flow.py
@@ -1,0 +1,94 @@
+"""Smoke coverage for the GUI-oriented project workflow used in Plotinator."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from config import PlotinatorConfig
+from plotinator.project import PlotinatorProject, ProjectManager
+
+
+def test_gui_project_flow(tmp_path: Path) -> None:
+    """Simulate the GUI operations of creating, editing, and saving a project."""
+
+    manager = ProjectManager()
+    project_root = tmp_path / "flow.p10k"
+    project = manager.new_project(project_root)
+
+    imported_data = project.paths.data_dir / "series.dat"
+    imported_data.write_text("0 0\n1 1\n2 4\n", encoding="utf-8")
+
+    initial_config = PlotinatorConfig.from_mapping(
+        {
+            "settings": {"output_dir": "../exports", "max_workers": 1},
+            "fits": [
+                {
+                    "title": "Initial Fit",
+                    "formula": "a * x + b",
+                    "residuals": True,
+                    "layout": {
+                        "rows": 1,
+                        "columns": 1,
+                        "shared_x": False,
+                        "shared_y": False,
+                        "show_legend": True,
+                    },
+                    "datasets": [
+                        {
+                            "label": "Series",
+                            "data_source": {
+                                "path": "series.dat",
+                                "columns": {"x": 1, "y": 2},
+                            },
+                        }
+                    ],
+                }
+            ],
+        },
+        base_path=project.paths.data_dir,
+    )
+    project.update_from_config(initial_config)
+
+    edited_config = PlotinatorConfig.from_mapping(
+        {
+            "settings": {"output_dir": "../exports", "max_workers": 2},
+            "fits": [
+                {
+                    "title": "Refined Fit",
+                    "formula": "a*x + b",
+                    "residuals": False,
+                    "layout": {
+                        "rows": 1,
+                        "columns": 1,
+                        "shared_x": False,
+                        "shared_y": False,
+                        "show_legend": True,
+                    },
+                    "datasets": [
+                        {
+                            "label": "Series",
+                            "data_source": {
+                                "path": "series.dat",
+                                "columns": {"x": 1, "y": 2},
+                            },
+                            "style": {"line_color": "#FF0000"},
+                        }
+                    ],
+                }
+            ],
+        },
+        base_path=project.paths.data_dir,
+    )
+    project.update_from_config(edited_config)
+
+    manager.save_project()
+
+    reopened = PlotinatorProject.load(project_root)
+    fit = reopened.config.fits[0]
+    dataset = fit.datasets[0]
+    assert fit.title == "Refined Fit"
+    assert fit.fit_formula == "a*x + b"
+    assert fit.residuals is False
+    assert reopened.config.settings.max_workers == 2
+    assert dataset.data_source.path == imported_data.resolve()
+    assert dataset.style.line_color == "#FF0000"

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,0 +1,149 @@
+"""Integration-style tests covering project persistence and migration flows."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from config import ConfigError, PlotinatorConfig
+from plotinator.project import PlotinatorProject, ProjectManager, migrate_config_file
+
+
+def _make_project_config(data_dir: Path) -> dict:
+    return {
+        "settings": {"output_dir": "../exports", "max_workers": 2},
+        "fits": [
+            {
+                "title": "Demo Fit",
+                "formula": "a * x + b",
+                "residuals": True,
+                "layout": {
+                    "rows": 1,
+                    "columns": 1,
+                    "shared_x": False,
+                    "shared_y": False,
+                    "show_legend": True,
+                },
+                "datasets": [
+                    {
+                        "label": "Dataset A",
+                        "data_source": {
+                            "path": "sample.dat",
+                            "columns": {"x": 1, "y": 2},
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def test_project_round_trip_via_manager(tmp_path: Path) -> None:
+    """Saving and reloading a project should preserve metadata and config."""
+
+    manager = ProjectManager()
+    project_root = tmp_path / "analysis.p10k"
+    project = manager.new_project(project_root)
+    project.metadata.label = "Analysis"
+    project.metadata.description = "Synthetic validation"
+
+    data_file = project.paths.data_dir / "sample.dat"
+    data_file.write_text("0 0\n1 1\n", encoding="utf-8")
+
+    config = PlotinatorConfig.from_mapping(_make_project_config(project.paths.data_dir), base_path=project.paths.data_dir)
+    project.update_from_config(config)
+
+    manager.save_project()
+
+    assert project.paths.metadata.exists()
+    assert project.paths.fits.exists()
+    assert project.paths.settings.exists()
+
+    reloaded = PlotinatorProject.load(project_root)
+    assert reloaded.metadata.label == "Analysis"
+    assert reloaded.metadata.description == "Synthetic validation"
+
+    dataset = reloaded.config.fits[0].datasets[0]
+    assert dataset.data_source.path == data_file.resolve()
+    assert dataset.data_source.original_path == "sample.dat"
+    assert reloaded.config.settings.output_dir == project.paths.exports_dir.resolve()
+
+
+def test_migration_materialises_legacy_workspace(tmp_path: Path) -> None:
+    """Migrating a legacy config.json copies datasets and normalises paths."""
+
+    legacy_root = tmp_path / "legacy"
+    legacy_root.mkdir()
+    legacy_data = legacy_root / "sample.dat"
+    legacy_data.write_text("0 0\n1 1\n2 4\n", encoding="utf-8")
+
+    legacy_config = legacy_root / "config.json"
+    legacy_payload = _make_project_config(legacy_root)
+    with legacy_config.open("w", encoding="utf-8") as handle:
+        json.dump(legacy_payload, handle)
+
+    target_root = tmp_path / "Migrated.p10k"
+    project = migrate_config_file(legacy_config, target_root)
+
+    assert project.paths.root == target_root
+    assert project.paths.metadata.is_file()
+    assert project.paths.fits.is_file()
+    assert project.paths.settings.is_file()
+    assert (project.paths.data_dir / "sample.dat").is_file()
+
+    migrated = PlotinatorProject.load(target_root)
+    dataset = migrated.config.fits[0].datasets[0]
+    assert dataset.data_source.path == (project.paths.data_dir / "sample.dat").resolve()
+    assert dataset.data_source.original_path == "sample.dat"
+
+
+def test_project_load_detects_invalid_dataset_columns(tmp_path: Path) -> None:
+    """Loading a project with invalid column references should raise ConfigError."""
+
+    project_root = tmp_path / "broken.p10k"
+    data_dir = project_root / "data"
+    plots_dir = project_root / "plots"
+    exports_dir = project_root / "exports"
+    for directory in (data_dir, plots_dir, exports_dir):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    (data_dir / "sample.dat").write_text("0 0\n1 1\n", encoding="utf-8")
+
+    metadata_path = project_root / "project.json"
+    metadata_path.write_text(json.dumps({"label": "Broken"}), encoding="utf-8")
+
+    settings_path = project_root / "settings.json"
+    settings_path.write_text(json.dumps({}), encoding="utf-8")
+
+    fits_payload = {
+        "fits": [
+            {
+                "title": "Bad Fit",
+                "formula": "a*x + b",
+                "residuals": True,
+                "layout": {
+                    "rows": 1,
+                    "columns": 1,
+                    "shared_x": False,
+                    "shared_y": False,
+                    "show_legend": True,
+                },
+                "datasets": [
+                    {
+                        "label": "Bad Dataset",
+                        "data_source": {
+                            "path": "sample.dat",
+                            "columns": {"x": 1, "y": 5},
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+    fits_path = project_root / "fits.json"
+    fits_path.write_text(json.dumps(fits_payload["fits"]), encoding="utf-8")
+
+    with pytest.raises(ConfigError):
+        PlotinatorProject.load(project_root)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -6,8 +6,9 @@ from typing import Optional
 
 import pytest
 
-from config import JobSettings
+from config import JobSettings, PlotinatorConfig
 from engine import runner
+from plotinator.project import ProjectManager
 
 
 def _install_pipeline_stubs(
@@ -15,6 +16,7 @@ def _install_pipeline_stubs(
     output_dir: Path,
     *,
     export_pdf_exception: Exception | None = None,
+    report_dir: Path | None = None,
 ) -> None:
     """Replace external tooling with deterministic fakes for the run pipeline."""
 
@@ -51,8 +53,11 @@ def _install_pipeline_stubs(
     def fake_compute_metrics(*_: object) -> dict[str, float]:
         return {"r2": 0.99, "rmse": 0.5}
 
+    report_root = report_dir or output_dir
+
     def fake_write_markdown(results_path: str) -> Path:
-        md_path = output_dir / "report.md"
+        report_root.mkdir(parents=True, exist_ok=True)
+        md_path = report_root / "report.md"
         md_path.write_text(f"results: {results_path}", encoding="utf-8")
         return md_path
 
@@ -240,3 +245,85 @@ def test_run_job_records_plot_failures(
     event_types = [event["type"] for event in events]
     assert "plot-error" in event_types
     assert "plot-complete" in event_types
+
+
+def test_run_job_with_project_directories(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Project-aware jobs should separate plot previews and exported reports."""
+
+    manager = ProjectManager()
+    project_root = tmp_path / "demo.p10k"
+    project = manager.new_project(project_root)
+
+    data_file = project.paths.data_dir / "sample.dat"
+    data_file.write_text("0 0\n1 1\n2 4\n", encoding="utf-8")
+
+    config_payload = {
+        "settings": {"output_dir": "../exports", "max_workers": 1},
+        "fits": [
+            {
+                "title": "Parabola",
+                "formula": "a*x + b",
+                "residuals": True,
+                "layout": {
+                    "rows": 1,
+                    "columns": 1,
+                    "shared_x": False,
+                    "shared_y": False,
+                    "show_legend": True,
+                },
+                "datasets": [
+                    {
+                        "label": "Main",
+                        "data_source": {
+                            "path": "sample.dat",
+                            "columns": {"x": 1, "y": 2},
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+
+    config = PlotinatorConfig.from_mapping(config_payload, base_path=project.paths.data_dir)
+    project.update_from_config(config)
+    manager.save_project()
+
+    events: list[dict] = []
+    _install_pipeline_stubs(
+        monkeypatch,
+        project.paths.plots_dir,
+        report_dir=project.paths.exports_dir,
+    )
+
+    job_config = project.to_config().to_dict()
+    project_config_path = project.paths.data_dir / "job.json"
+    project_config_path.write_text("{}", encoding="utf-8")
+    result = runner.run_job(
+        job_config,
+        config_path=str(project_config_path),
+        settings=project.config.settings,
+        output_dir=project.paths.plots_dir,
+        on_event=events.append,
+    )
+
+    output_dir = Path(result["output_dir"])
+    assert output_dir == project.paths.plots_dir
+    assert Path(result["results_path"]).parent == project.paths.plots_dir
+    assert Path(result["markdown_path"]).parent == project.paths.exports_dir
+    assert Path(result["pdf_path"]).parent == project.paths.exports_dir
+
+    first_result = result["results"][0]
+    plot_path = Path(first_result["output_plot"])
+    assert project.paths.plots_dir in plot_path.parents or plot_path.parent == project.paths.plots_dir
+    residual_path = first_result["residuals_plot"]
+    if residual_path:
+        residual_path_obj = Path(residual_path)
+        assert (
+            project.paths.plots_dir in residual_path_obj.parents
+            or residual_path_obj.parent == project.paths.plots_dir
+        )
+
+    assert any(event["type"] == "report-exported" for event in events)


### PR DESCRIPTION
## Summary
- add integration-style project tests covering persistence, migration, and validation scenarios
- extend the engine runner test harness to ensure project contexts write plots and exports to the expected folders
- provide a GUI smoke test that simulates creating, editing, and saving a project

## Testing
- pytest tests/test_project.py tests/test_runner.py::test_run_job_with_project_directories tests/smoke/test_gui_project_flow.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c8808a90832880d11c3fcfc8c0aa)