### PR TITLE
Add project-aware CLI options for Plotinator

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,16 @@ pip install .[dev]    # install pytest + ruff for local development
 
 ```bash
 plotinator-cli path/to/config.json
+plotinator-cli path/to/project.p10k
+plotinator-cli path/to/project.p10k --output-dir /custom/exports
 ```
 
-- Reads the configuration file using the schema models.
+- Accepts either a legacy `config.json` file or a modern `.p10k` project directory.
 - Normalises dataset layouts and style configuration.
-- Executes gnuplot fits (with optional parallel workers) and writes results to `outputs/<timestamp>/`.
+- Exports to the project's configured output directory unless `--output-dir` is provided, otherwise
+  falls back to `outputs/<timestamp>/`.
+- Executes gnuplot fits (with optional parallel workers) and writes results to the selected output
+  directory.
 
 ### Launch the desktop GUI
 

--- a/plot_manager.py
+++ b/plot_manager.py
@@ -1,16 +1,129 @@
 from __future__ import annotations
 
+import argparse
+import os
 import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
 
-from engine.runner import run_batch
+from config.schema import JobSettings
+from engine.runner import run_batch, run_job
+from plotinator.project import PlotinatorProject
+
+
+@dataclass(slots=True)
+class _JobRequest:
+    """Container describing how the engine should be invoked."""
+
+    config_path: str
+    config_payload: dict[str, Any] | None = None
+    settings: JobSettings | None = None
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="plotinator-cli",
+        description=(
+            "Execute Plotinator batch fits using a configuration file or a .p10k project "
+            "directory."
+        ),
+    )
+    parser.add_argument(
+        "source",
+        nargs="?",
+        help=(
+            "Path to config.json or a .p10k project directory. Defaults to ./config.json "
+            "when omitted."
+        ),
+    )
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        metavar="PATH",
+        help=(
+            "Write plots, residuals, and reports to PATH instead of the project settings or "
+            "timestamped defaults."
+        ),
+    )
+    return parser
+
+
+def _resolve_job_request(target: str | None) -> _JobRequest:
+    """Resolve CLI target into a configuration payload for the engine."""
+
+    if not target:
+        return _JobRequest(config_path=str(Path("config.json").resolve()))
+
+    raw_path = Path(target).expanduser()
+    path = raw_path.resolve()
+    if path.is_dir():
+        project_marker = path / "project.json"
+        if project_marker.is_file():
+            return _job_request_from_project(path)
+        config_candidate = path / "config.json"
+        if config_candidate.is_file():
+            return _JobRequest(config_path=str(config_candidate))
+    elif path.is_file():
+        if path.name == "project.json" and path.parent.is_dir():
+            return _job_request_from_project(path.parent)
+        if path.suffix == ".p10k":
+            return _job_request_from_project(path)
+        return _JobRequest(config_path=str(path))
+
+    if raw_path.suffix == ".p10k" or path.suffix == ".p10k":
+        if path.exists():
+            return _job_request_from_project(path)
+        raise FileNotFoundError(f"Project directory not found: {target}")
+
+    if raw_path.name == "project.json" and path.parent.is_dir():
+        return _job_request_from_project(path.parent)
+
+    return _JobRequest(config_path=str(path))
+
+
+def _job_request_from_project(root: Path) -> _JobRequest:
+    project_root = Path(root)
+    if not project_root.exists():
+        raise FileNotFoundError(f"Project directory not found: {project_root}")
+    project = PlotinatorProject.load(project_root)
+    config = project.to_config()
+    payload = config.to_dict()
+    virtual_config_path = project.paths.data_dir / "config.json"
+    return _JobRequest(
+        config_path=str(virtual_config_path),
+        config_payload=payload,
+        settings=config.settings,
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = sys.argv if argv is None else argv
-    config_path = args[1] if len(args) > 1 else "config.json"
+    parser = _build_parser()
+    args = parser.parse_args(argv)
 
     try:
-        run_batch(config_path)
+        job_request = _resolve_job_request(args.source)
+    except FileNotFoundError as exc:
+        parser.error(str(exc))
+        return 2
+
+    output_dir = args.output_dir
+    if output_dir:
+        output_dir = os.fspath(Path(output_dir).expanduser().resolve())
+
+    try:
+        if job_request.config_payload is not None:
+            run_job(
+                job_request.config_payload,
+                config_path=job_request.config_path,
+                settings=job_request.settings,
+                output_dir=output_dir,
+            )
+        else:
+            run_batch(
+                job_request.config_path,
+                output_dir=output_dir,
+            )
     except Exception as exc:  # noqa: BLE001 - convert to CLI status code
         print(f"[X] {exc}")
         return 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 import plot_manager
@@ -8,8 +10,8 @@ import plot_manager
 @pytest.mark.parametrize(
     "argv,expected_path",
     [
-        (["plot_manager.py", "custom.json"], "custom.json"),
-        (["plot_manager.py"], "config.json"),
+        (["custom.json"], "custom.json"),
+        ([], "config.json"),
     ],
 )
 def test_main_success(
@@ -20,17 +22,19 @@ def test_main_success(
 ) -> None:
     """plot_manager.main should delegate to run_batch and return success."""
 
-    call_args: dict[str, str] = {}
+    call_args: dict[str, str | None] = {}
 
-    def fake_run_batch(path: str) -> None:
+    def fake_run_batch(path: str, *, output_dir: str | None = None) -> None:
         call_args["path"] = path
+        call_args["output_dir"] = output_dir
 
     monkeypatch.setattr(plot_manager, "run_batch", fake_run_batch)
 
     exit_code = plot_manager.main(argv)
 
     assert exit_code == 0
-    assert call_args["path"] == expected_path
+    assert call_args["path"] == str(Path(expected_path).resolve())
+    assert call_args["output_dir"] is None
     captured = capsys.readouterr()
     assert captured.out == ""
     assert captured.err == ""
@@ -42,12 +46,12 @@ def test_main_missing_config(
 ) -> None:
     """Missing configuration files should yield an error status and message."""
 
-    def fake_run_batch(path: str) -> None:
+    def fake_run_batch(path: str, *, output_dir: str | None = None) -> None:
         raise FileNotFoundError(f"{path} does not exist")
 
     monkeypatch.setattr(plot_manager, "run_batch", fake_run_batch)
 
-    exit_code = plot_manager.main(["plot_manager.py"])  # Default path resolved internally
+    exit_code = plot_manager.main([])  # Default path resolved internally
 
     assert exit_code == 1
     captured = capsys.readouterr()
@@ -61,12 +65,12 @@ def test_main_handles_unexpected_exceptions(
 ) -> None:
     """Unexpected exceptions should be surfaced with a non-zero exit code."""
 
-    def fake_run_batch(_: str) -> None:
+    def fake_run_batch(_: str, *, output_dir: str | None = None) -> None:
         raise RuntimeError("boom")
 
     monkeypatch.setattr(plot_manager, "run_batch", fake_run_batch)
 
-    exit_code = plot_manager.main(["plot_manager.py", "custom.json"])
+    exit_code = plot_manager.main(["custom.json"])
 
     assert exit_code == 1
     captured = capsys.readouterr()

--- a/tests/test_plot_manager_cli.py
+++ b/tests/test_plot_manager_cli.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import plot_manager
+from config.schema import PlotinatorConfig
+from plotinator.project import PlotinatorProject, ProjectMetadata, ProjectPaths
+
+
+def _create_project(root: Path) -> PlotinatorProject:
+    data_dir = root / "data"
+    data_dir.mkdir(parents=True)
+    (data_dir / "sample.dat").write_text("1 2\n", encoding="utf-8")
+
+    config_payload = {
+        "settings": {"output_dir": "../exports"},
+        "fits": [
+            {
+                "title": "Example",
+                "formula": "a * x + b",
+                "datasets": [
+                    {
+                        "label": "Dataset",
+                        "data_source": {
+                            "path": "sample.dat",
+                            "columns": {"x": 1, "y": 2},
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+    config = PlotinatorConfig.from_mapping(config_payload, base_path=data_dir)
+    project = PlotinatorProject(
+        paths=ProjectPaths.from_root(root),
+        metadata=ProjectMetadata(label="Example"),
+        config=config,
+    )
+    project.save()
+    return project
+
+
+def test_resolve_job_request_defaults_to_config_json():
+    request = plot_manager._resolve_job_request(None)
+    assert request.config_path.endswith("config.json")
+    assert request.config_payload is None
+    assert request.settings is None
+
+
+def test_resolve_job_request_from_project(tmp_path: Path):
+    project_root = tmp_path / "demo.p10k"
+    project = _create_project(project_root)
+
+    request = plot_manager._resolve_job_request(str(project_root))
+    assert request.config_payload is not None
+    assert Path(request.config_path).parent == project.paths.data_dir
+    assert request.settings is not None
+
+
+def test_main_invokes_run_job_for_projects(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    project_root = tmp_path / "demo.p10k"
+    project = _create_project(project_root)
+
+    captured: dict[str, object] = {}
+
+    def fake_run_job(config_payload, *, config_path, settings, output_dir):  # noqa: ANN001
+        captured.update(
+            {
+                "payload": config_payload,
+                "config_path": config_path,
+                "settings": settings,
+                "output_dir": output_dir,
+            }
+        )
+        return {"output_dir": output_dir}
+
+    monkeypatch.setattr(plot_manager, "run_job", fake_run_job)
+
+    custom_output = tmp_path / "exports"
+    exit_code = plot_manager.main([str(project_root), "--output-dir", str(custom_output)])
+
+    assert exit_code == 0
+    assert captured["payload"] is not None
+    assert Path(captured["config_path"]).parent == project.paths.data_dir
+    assert captured["settings"] == project.config.settings
+    assert captured["output_dir"] == str(custom_output.resolve())
+
+
+def test_main_invokes_run_batch_for_configs(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}", encoding="utf-8")
+
+    captured: dict[str, object] = {}
+
+    def fake_run_batch(path, *, output_dir=None):  # noqa: ANN001
+        captured.update({"path": path, "output_dir": output_dir})
+        return {"output_dir": output_dir}
+
+    monkeypatch.setattr(plot_manager, "run_batch", fake_run_batch)
+
+    exit_code = plot_manager.main([str(config_path), "-o", "exports"])
+
+    assert exit_code == 0
+    assert captured["path"] == str(config_path.resolve())
+    assert captured["output_dir"] == str(Path("exports").resolve())
+
+
+def test_resolve_job_request_missing_target() -> None:
+    with pytest.raises(FileNotFoundError):
+        plot_manager._resolve_job_request("missing-project.p10k")


### PR DESCRIPTION
## Summary
- extend the CLI to resolve .p10k projects, pipe their embedded configuration to the engine, and expose an --output-dir override
- document the new usage patterns in the README for both legacy configs and modern projects
- cover the new code paths with focused CLI and project tests

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918c86cb64483288c005e296bf59188)