### PR TITLE
Add save_project helper and allow silent save feedback

### DIFF
--- a/plotinator_gui.py
+++ b/plotinator_gui.py
@@ -2024,7 +2024,10 @@ class PlotinatorApp(ttkb.Window):
             pass
 
 
-    def save_config(self) -> bool:
+    def save_project(self, *, show_feedback: bool = True) -> bool:
+        return self.save_config(show_feedback=show_feedback)
+
+    def save_config(self, *, show_feedback: bool = True) -> bool:
         project = self._project
         if project is None:
             return False
@@ -2039,7 +2042,8 @@ class PlotinatorApp(ttkb.Window):
         self._project = project
         self._write_engine_config(project)
         self.folder = project.paths.data_dir
-        self.show_toast("Project saved", level="success")
+        if show_feedback:
+            self.show_toast("Project saved", level="success")
         self._app_state.record_project(project.paths.root)
         self._app_state.save()
         self._update_recent_projects_menu()


### PR DESCRIPTION
## Summary
- add a save_project wrapper so callers like run_batch can invoke saves safely
- allow suppressing success toast messages when saving configurations

## Testing
- python -m pytest tests/test_cli.py tests/test_plot_manager_cli.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a95e3509483288303973bf15f34bd)