### PR TITLE
Handle project-root relative data paths

### DIFF
--- a/config/schema.py
+++ b/config/schema.py
@@ -255,9 +255,14 @@ class DataSourceConfig:
         if not raw_path:
             raise ConfigError(f"{context} requires a 'path'")
         raw_path_str = str(raw_path)
-        candidate = Path(raw_path_str)
+        raw_candidate = Path(raw_path_str).expanduser()
+        candidate = raw_candidate
         if not candidate.is_absolute():
             candidate = (base_dir / candidate).resolve()
+        if not candidate.exists() and not raw_candidate.is_absolute():
+            fallback = (base_dir.parent / raw_candidate).resolve()
+            if fallback.exists():
+                candidate = fallback
         if not candidate.exists():
             raise ConfigError(f"Data file not found for {context}: {raw_path_str}")
         columns = ColumnMapping.from_mapping(data.get("columns"), context=f"{context}.columns")

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -75,3 +75,33 @@ def test_load_config_file_requires_pyyaml(sample_paths) -> None:
 
     with pytest.raises(ConfigError, match="PyYAML is required to load YAML configuration files"):
         load_config_file(yaml_path)
+
+
+def test_data_source_accepts_project_root_relative_paths(sample_paths: SimpleNamespace) -> None:
+    """Relative paths anchored at the project root should resolve inside data/."""
+
+    project_root = sample_paths.config_dir / "demo_project"
+    data_dir = project_root / "data"
+    data_dir.mkdir(parents=True)
+
+    data_file = data_dir / "series.dat"
+    data_file.write_text("0 0\n1 1\n", encoding="utf-8")
+
+    config_payload = {
+        "fits": [
+            {
+                "title": "Root-relative dataset",
+                "formula": "m*x + c",
+                "data_source": {
+                    "path": f"data/{data_file.name}",
+                    "columns": {"x": 1, "y": 2},
+                },
+            }
+        ]
+    }
+
+    config = load_config(config_payload, base_path=data_dir)
+
+    data_source = config.fits[0].datasets[0].data_source
+    assert data_source.path == data_file
+    assert data_source.original_path == f"data/{data_file.name}"


### PR DESCRIPTION
## Summary
- allow data file resolution to fall back to paths relative to the project root when base_dir points at a data directory
- expand dataset path handling to cover user-home shortcuts while keeping original path strings intact
- add regression coverage to ensure project-root-relative dataset paths resolve successfully

## Testing
- pytest tests/test_config_validation.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d482923748328a42be34ef520ce38)